### PR TITLE
Optimised caching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name="pipelinewise-target-snowflake",
-      version="1.0.5",
+      version="1.0.6",
       description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
Query and load the cache table into memory at startup and pass it to every component at runtime. This minimises the number of queries to the cache table in Snowflake.


Currently we run this query every time when a singer `SCHEMA` message consumes:
```
SELECT LOWER(c.table_schema) table_schema, LOWER(c.table_name) table_name, c.column_name, c.data_type
            FROM pipelinewise.columns c
            WHERE 1 = 1 AND LOWER(c.table_schema) = '{target_schema}`
```


For example if a tap has 200 tables then we run the above query 200 times. Each of them takes a couple of seconds and it gives 4-5 extra minute to the startup time.
