### PR TITLE
Bump to latest snowflake-connector-python version is required. Current version fails to connect to snowflake.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 idna==2.7
 singer-python==5.1.1
-snowflake-connector-python==1.7.4
+snowflake-connector-python==2.0.1
 boto3==1.9.33
 inflection==0.3.1
 joblib==0.13.2


### PR DESCRIPTION
The old snowflake python connector now fails with an error asn1cryptokeys.PublicKeyInfo().unwrap() has been removed, please use oscrypto.asymmetric.PublicKey().unwrap() instead. Snowflake have fixed this but it requires the latest snowflake-connector-python (2.0.1)

See: https://github.com/snowflakedb/snowflake-connector-python/commit/5ad17f6491c1bfe87facd8b367fd51b519f2fd03