### PR TITLE
Update flushed_state only if state received from tap

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -325,7 +325,7 @@ def flush_streams(
         # Update flushed streams
         if filter_streams:
             # update flushed_state position if we have state information for the stream
-            if stream in state.get('bookmarks', {}):
+            if state is not None and stream in state.get('bookmarks', {}):
                 # Create bookmark key if not exists
                 if 'bookmarks' not in flushed_state:
                     flushed_state['bookmarks'] = {}


### PR DESCRIPTION
Fixes #41

STATE message is not mandatory by the singer spec and target-snowflake should not expect that the tap already sent a valid STATE message when flushing batches. Further details in #41