### PR TITLE
[AP-473] refactor Logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,21 +18,20 @@ jobs:
           name: 'Pylinting'
           command: |
             . venv/bin/activate
-            pip install .[test]
             pylint target_snowflake -d C,W,unexpected-keyword-arg,duplicate-code
 
       - run:
           name: 'Unit Tests'
           command: |
             . venv/bin/activate
-            pip install .[test]
+            export LOGGING_CONF_FILE=$(pwd)/sample_logging.conf
             nosetests --where=tests/unit
 
       - run:
           name: 'Integration Tests'
           command: |
             . venv/bin/activate
-            pip install .[test]
+            export LOGGING_CONF_FILE=$(pwd)/sample_logging.conf
             nosetests --where=tests/integration/
 
 workflows:

--- a/sample_logging.conf
+++ b/sample_logging.conf
@@ -1,0 +1,25 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=stderr
+
+[formatters]
+keys=child
+
+[logger_root]
+level=INFO
+handlers=stderr
+formatter=child
+propagate=0
+
+[handler_stderr]
+level=INFO
+class=StreamHandler
+formatter=child
+args=(sys.stderr,)
+
+[formatter_child]
+class=logging.Formatter
+format=time=%(asctime)s name=%(name)s level=%(levelname)s message=%(message)s
+datefmt=%Y-%m-%d %H:%M:%S

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/.env python
 
 from setuptools import setup
 
 with open('README.md') as f:
-      long_description = f.read()
+    long_description = f.read()
 
 setup(name="pipelinewise-target-snowflake",
       version="1.4.1",
@@ -19,7 +19,7 @@ setup(name="pipelinewise-target-snowflake",
       py_modules=["target_snowflake"],
       install_requires=[
           'idna==2.7',
-          'singer-python==5.1.1',
+          'pipelinewise-singer-python==1.*',
           'snowflake-connector-python==2.0.3',
           'boto3==1.10.8',
           'botocore==1.13.8',
@@ -40,6 +40,4 @@ setup(name="pipelinewise-target-snowflake",
           target-snowflake=target_snowflake:main
       """,
       packages=["target_snowflake"],
-      package_data = {},
-      include_package_data=True,
-)
+      )

--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -1,25 +1,29 @@
-#!/usr/bin/env python3
+#!/usr/bin/.env python3
 
 import argparse
 import io
 import json
+import logging
 import os
 import sys
 import copy
-import singer
 
 from datetime import datetime
 from decimal import Decimal
-from tempfile import NamedTemporaryFile, mkstemp
+from tempfile import mkstemp
 from typing import Dict
 from dateutil import parser
 from dateutil.parser import ParserError
 from joblib import Parallel, delayed, parallel_backend
 from jsonschema import Draft4Validator, FormatChecker
+from singer import get_logger
 
 from target_snowflake.db_sync import DbSync
 
-logger = singer.get_logger()
+LOGGER = get_logger('target_snowflake')
+
+# Tone down snowflake.connector log noise by only outputting warnings and higher level messages
+logging.getLogger('snowflake.connector').setLevel(logging.WARNING)
 
 DEFAULT_BATCH_SIZE_ROWS = 100000
 DEFAULT_PARALLELISM = 0  # 0 The number of threads used to flush tables
@@ -89,7 +93,7 @@ def add_metadata_values_to_record(record_message, stream_to_sync):
 def emit_state(state):
     if state is not None:
         line = json.dumps(state)
-        logger.info('Emitting state {}'.format(line))
+        LOGGER.info('Emitting state {}'.format(line))
         sys.stdout.write("{}\n".format(line))
         sys.stdout.flush()
 
@@ -111,8 +115,8 @@ def get_schema_names_from_config(config):
 
 def load_information_schema_cache(config):
     information_schema_cache = []
-    if not ('disable_table_cache' in config and config['disable_table_cache'] == True):
-        logger.info("Getting catalog objects from information_schema cache table...")
+    if not ('disable_table_cache' in config and config['disable_table_cache']):
+        LOGGER.info("Getting catalog objects from information_schema cache table...")
 
         db = DbSync(config)
         information_schema_cache = db.get_table_columns(
@@ -149,6 +153,7 @@ def adjust_timestamps_in_record(record: Dict, schema: Dict) -> None:
                         schema['properties'][key].get('format', None) in {'date-time', 'time', 'date'}:
                     reset_new_value(record, key, schema['properties'][key]['format'])
 
+
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def persist_lines(config, lines, information_schema_cache=None) -> None:
     state = None
@@ -167,7 +172,7 @@ def persist_lines(config, lines, information_schema_cache=None) -> None:
         try:
             o = json.loads(line)
         except json.decoder.JSONDecodeError:
-            logger.error("Unable to parse:\n{}".format(line))
+            LOGGER.error("Unable to parse:\n{}".format(line))
             raise
 
         if 'type' not in o:
@@ -268,7 +273,7 @@ def persist_lines(config, lines, information_schema_cache=None) -> None:
             #  or
             #  2) Use fastsync [postgres-to-snowflake, mysql-to-snowflake, etc.]
             if config.get('primary_key_required', True) and len(o['key_properties']) == 0:
-                logger.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))
+                LOGGER.critical("Primary key is set to mandatory but not defined in the [{}] stream".format(stream))
                 raise Exception("key_properties field is required")
 
             key_properties[stream] = o['key_properties']
@@ -293,10 +298,10 @@ def persist_lines(config, lines, information_schema_cache=None) -> None:
             total_row_count[stream] = 0
 
         elif t == 'ACTIVATE_VERSION':
-            logger.debug('ACTIVATE_VERSION message')
+            LOGGER.debug('ACTIVATE_VERSION message')
 
         elif t == 'STATE':
-            logger.debug('Setting state to {}'.format(o['value']))
+            LOGGER.debug('Setting state to {}'.format(o['value']))
             state = o['value']
 
             # Initially set flushed state
@@ -418,7 +423,7 @@ def flush_records(stream, records_to_load, row_count, db_sync, temp_dir=None):
     try:
         db_sync.load_csv(s3_key, row_count)
     except Exception as e:
-        logger.error("""
+        LOGGER.error("""
             Cannot load data from S3 into Snowflake schema: {} .
             Try to delete {}.COLUMNS table to reset information_schema cache. Maybe it's outdated.
         """.format(db_sync.schema_name, db_sync.pipelinewise_schema.upper()))
@@ -429,9 +434,9 @@ def flush_records(stream, records_to_load, row_count, db_sync, temp_dir=None):
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--config', help='Config file')
-    args = parser.parse_args()
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('-c', '--config', help='Config file')
+    args = arg_parser.parse_args()
 
     if args.config:
         with open(args.config) as config_input:
@@ -446,7 +451,7 @@ def main():
     singer_messages = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     persist_lines(config, singer_messages, information_schema_cache)
 
-    logger.debug("Exiting normally")
+    LOGGER.debug("Exiting normally")
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -7,7 +7,7 @@ import os
 from nose.tools import assert_raises
 
 import target_snowflake
-from target_snowflake import RecordValidationException, InvalidTableStructureException
+from target_snowflake import RecordValidationException
 from target_snowflake.db_sync import DbSync
 
 from snowflake.connector.errors import ProgrammingError

--- a/tests/unit/test_target_snowflake.py
+++ b/tests/unit/test_target_snowflake.py
@@ -11,10 +11,9 @@ class TestTargetSnowflake(unittest.TestCase):
     def setUp(self):
         self.config = {}
 
-    @patch('target_snowflake.NamedTemporaryFile')
     @patch('target_snowflake.flush_streams')
     @patch('target_snowflake.DbSync')
-    def test_persist_lines_with_40_records_and_batch_size_of_20_expect_flushing_once(self, dbSync_mock, flush_streams_mock, temp_file_mock):
+    def test_persist_lines_with_40_records_and_batch_size_of_20_expect_flushing_once(self, dbSync_mock, flush_streams_mock):
         self.config['batch_size_rows'] = 20
         self.config['flush_all_streams'] = True
 


### PR DESCRIPTION
# Description
Switching to using Transferwise's singer fork instead of the Stitch's, this allows to configure logging however we want.
Given that pipelinewise-target-snowflake is also a pip module, it doesn't force any logging configuration and it's up to the final caller to do so.

Example of logs when `LOGGIN_CONG_FILE` is set:
```
time=2020-02-06 15:02:06 name=target_snowflake level=INFO message=Table 'sam_test.test_binary' exists
time=2020-02-06 15:02:17 name=target_snowflake level=INFO message=Uploading 3 rows to external snowflake stage on S3
time=2020-02-06 15:02:17 name=target_snowflake level=INFO message=Target S3 bucket: tw-staging-analyticsdb-etl, local file: /tmp/records_nrof1wdy.csv, S3 key: snowflake-imports-test/pipelinewise_tap_mysql_test-test_binary_20200206-150217-810000.csv
time=2020-02-06 15:02:18 name=target_snowflake level=INFO message=Loading 3 rows into 'sam_test.test_binary'
time=2020-02-06 15:02:21 name=target_snowflake level=INFO message=SNOWFLAKE - Merge into sam_test.test_binary: [{'number of rows inserted': 1, 'number of rows updated': 2}]
time=2020-02-06 15:02:21 name=target_snowflake level=INFO message=Deleting snowflake-imports-test/pipelinewise_tap_mysql_test-test_binary_20200206-150217-810000.csv from external snowflake stage on S3
time=2020-02-06 15:02:21 name=target_snowflake level=INFO message=Deleting rows from 'sam_test.test_binary' table... DELETE FROM sam_test.test_binary WHERE _sdc_deleted_at IS NOT NULL
time=2020-02-06 15:02:22 name=target_snowflake level=INFO message=DELETE 0
time=2020-02-06 15:02:22 name=target_snowflake level=INFO message=Emitting state {"currently_syncing": null, "bookmarks": {"tap_mysql_test-test_binary": {"version": 1576670613163, "log_file": "mysql-bin.000004", "log_pos": 945}}}
time=2020-02-06 15:02:26 name=target_snowflake level=INFO message=Table 'sam_test.test_binary' exists
time=2020-02-06 15:02:29 name=target_snowflake level=INFO message=Uploading 2 rows to external snowflake stage on S3
time=2020-02-06 15:02:29 name=target_snowflake level=INFO message=Target S3 bucket: tw-staging-analyticsdb-etl, local file: /tmp/records_q_qu68f7.csv, S3 key: snowflake-imports-test/pipelinewise_tap_mysql_test-test_binary_20200206-150229-104406.csv
time=2020-02-06 15:02:29 name=target_snowflake level=INFO message=Loading 2 rows into 'sam_test.test_binary'
time=2020-02-06 15:02:31 name=target_snowflake level=INFO message=SNOWFLAKE - Merge into sam_test.test_binary: [{'number of rows inserted': 1, 'number of rows updated': 1}]
time=2020-02-06 15:02:31 name=target_snowflake level=INFO message=Deleting snowflake-imports-test/pipelinewise_tap_mysql_test-test_binary_20200206-150229-104406.csv from external snowflake stage on S3
time=2020-02-06 15:02:31 name=target_snowflake level=INFO message=Deleting rows from 'sam_test.test_binary' table... DELETE FROM sam_test.test_binary WHERE _sdc_deleted_at IS NOT NULL
time=2020-02-06 15:02:33 name=target_snowflake level=INFO message=DELETE 1
time=2020-02-06 15:02:33 name=target_snowflake level=INFO message=Emitting state {"currently_syncing": null, "bookmarks": {"tap_mysql_test-test_binary": {"version": 1576670613163, "log_file": "mysql-bin.000004", "log_pos": 1867}}}

```

## Manual tests
1- Install the library using `pip3 install -e .[test]`
2- Prepare a config file and some streams to send to snowflake.

### Test without logging conf
3- run `cat streams.json | target-snowflake -c config.json 2> .log`
4- open the new file .log, it should not contain any logs

### Test with logging conf
3- run export LOGGING_CONF_FILE=./sample_logging.conf
4- run `cat streams.json | target-snowflake -c config.json 2> .log`
5- open the new file .log, it should contain logs with INFO level or higher.

## Risks
For users that currently use this library, if they upgrade to these changes, they will stop seeing logs unless they provide a logging config file.

## Rollback steps
Revert