### PR TITLE
[AP-760] Fixed bad return value from multiple queries in one transaction

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -327,8 +327,7 @@ class DbSync:
                         raise TooManyRecordsException(
                             f"Query returned too many records. This query can return max {max_records} records")
 
-                    if cur.rowcount > 0:
-                        result = cur.fetchall()
+                    result = cur.fetchall()
 
         return result
 


### PR DESCRIPTION
This is a fix for https://github.com/transferwise/pipelinewise-target-snowflake/issues/78

When multiple queries running in one transaction, the [db_sync.query](https://github.com/transferwise/pipelinewise-target-snowflake/blob/afb9c92d2f1f0c539b37f5ebeb1c7370df27d05d/target_snowflake/db_sync.py#L308) function should return the result of the last query in the transaction. This is not the case when the query in the transaction returns zero record. When this happens, the function returns something wrong:
```
[{'status': 'Statement executed successfully.'}]
```

The output above is the output of the `START TRANSACTION` statement which is wrong. In this case the [db_sync.query](https://github.com/transferwise/pipelinewise-target-snowflake/blob/afb9c92d2f1f0c539b37f5ebeb1c7370df27d05d/target_snowflake/db_sync.py#L308) function should return the empty list instead.