### PR TITLE
Fix: accept empty schema

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -145,7 +145,7 @@ def adjust_timestamps_in_record(record: Dict, schema: Dict) -> None:
                         reset_new_value(record, key, type_dict['format'])
                         break
             else:
-                if 'string' in schema['properties'][key]['type'] and \
+                if 'string' in schema['properties'][key].get('type', []) and \
                         schema['properties'][key].get('format', None) in {'date-time', 'time', 'date'}:
                     reset_new_value(record, key, schema['properties'][key]['format'])
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -51,10 +51,10 @@ def validate_config(config):
 
 
 def column_type(schema_property):
-    property_type = schema_property['type']
+    property_type = schema_property.get('type', [])
     property_format = schema_property['format'] if 'format' in schema_property else None
     column_type = 'text'
-    if 'object' in property_type or 'array' in property_type:
+    if 'object' in property_type or 'array' in property_type or property_type == []:
         column_type = 'variant'
 
     # Every date-time JSON value is currently mapped to TIMESTAMP_NTZ
@@ -80,9 +80,11 @@ def column_type(schema_property):
 
 
 def column_trans(schema_property):
-    property_type = schema_property['type']
+    property_type = schema_property.get('type', [])
     column_trans = ''
-    if 'object' in property_type or 'array' in property_type:
+    if property_type == []:
+        column_trans = 'to_variant'
+    elif 'object' in property_type or 'array' in property_type:
         column_trans = 'parse_json'
     elif schema_property.get('format') == 'binary':
         column_trans = 'to_binary'
@@ -135,6 +137,9 @@ def flatten_schema(d, parent_key=[], sep='__', level=0, max_level=0):
                 elif list(v.values())[0][0]['type'] == 'object':
                     list(v.values())[0][0]['type'] = ['null', 'object']
                     items.append((new_key, list(v.values())[0][0]))
+            else:
+                # In case of empty schema {}
+                items.append((new_key, {}))
 
     key_func = lambda item: item[0]
     sorted_items = sorted(items, key=key_func)


### PR DESCRIPTION
Closes #88 

- Fixes bugs in the code that caused `KeyError` exceptions when empty Schema is received
- Implement handling of empty schema fields as `Variant` datatype in Snowflake