### PR TITLE
Support ACL for S3 uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .vscode
 .idea/*
 
-
 # Python
 __pycache__/
 *.py[cod]
@@ -30,3 +29,6 @@ tmp
 # Docs
 docs/_build/
 docs/_templates/
+
+# Environment
+.env

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ Full list of options in `config.json`:
 | aws_access_key_id                   | String  | No         | S3 Access Key Id. If not provided, AWS_ACCESS_KEY_ID environment variable or IAM role will be used |
 | aws_secret_access_key               | String  | No         | S3 Secret Access Key. If not provided, AWS_SECRET_ACCESS_KEY environment variable or IAM role will be used |
 | aws_session_token                   | String  | No         | AWS Session token. If not provided, AWS_SESSION_TOKEN environment variable will be used |
+| s3_acl                              | String  | No         | S3 ACL name                                                |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
-| s3_key_prefix                       | String  |            | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can upload files into specific directories in the S3 bucket. |
+| s3_key_prefix                       | String  | No         | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can upload files into specific directories in the S3 bucket. |
 | stage                               | String  | Yes        | Named external stage name created at pre-requirements section. Has to be a fully qualified name including the schema name |
 | file_format                         | String  | Yes        | Named file format name created at pre-requirements section. Has to be a fully qualified name including the schema name. |
 | batch_size_rows                     | Integer |            | (Default: 100000) Maximum number of rows in each batch. At the end of each batch, the rows in the batch are loaded into Snowflake. |
@@ -158,7 +159,7 @@ Full list of options in `config.json`:
 
 ### To run tests:
 
-1. Define environment variables that requires running the tests
+1. Define the environment variables that are required to run the tests by creating a `.env` file in `tests/integration`, or by exporting the variables below.
 ```
   export TARGET_SNOWFLAKE_ACCOUNT=<snowflake-account-name>
   export TARGET_SNOWFLAKE_DBNAME=<snowflake-database-name>
@@ -168,6 +169,7 @@ Full list of options in `config.json`:
   export TARGET_SNOWFLAKE_SCHEMA=<snowflake-schema>
   export TARGET_SNOWFLAKE_AWS_ACCESS_KEY=<aws-access-key-id>
   export TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY=<aws-access-secret-access-key>
+  export TARGET_SNOWFLAKE_S3_ACL=<s3-target-acl>
   export TARGET_SNOWFLAKE_S3_BUCKET=<s3-external-bucket>
   export TARGET_SNOWFLAKE_S3_KEY_PREFIX=<bucket-directory>
   export TARGET_SNOWFLAKE_STAGE=<stage-object-with-schema-name>

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(name="pipelinewise-target-snowflake",
           "test": [
               "nose==1.3.7",
               "mock==3.0.5",
-              "pylint==2.4.2"
+              "pylint==2.4.2",
+              "python-dotenv==0.14.0"
           ]
       },
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name="pipelinewise-target-snowflake",
-      version="1.6.6",
+      version="1.6.7",
       description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name="pipelinewise-target-snowflake",
-      version="1.6.7",
+      version="1.6.6",
       description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tests/integration/.env.sample
+++ b/tests/integration/.env.sample
@@ -1,0 +1,15 @@
+TARGET_SNOWFLAKE_ACCOUNT=<snowflake-account-name>
+TARGET_SNOWFLAKE_DBNAME=<snowflake-database-name>
+TARGET_SNOWFLAKE_USER=<snowflake-user>
+TARGET_SNOWFLAKE_PASSWORD=<snowfale-password>
+TARGET_SNOWFLAKE_WAREHOUSE=<snowflake-warehouse>
+TARGET_SNOWFLAKE_SCHEMA=<snowflake-schema>
+TARGET_SNOWFLAKE_AWS_ACCESS_KEY=<aws-access-key-id>
+TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY=<aws-access-secret-access-key>
+TARGET_SNOWFLAKE_S3_ACL=<s3-target-acl>
+TARGET_SNOWFLAKE_S3_BUCKET=<s3-external-bucket>
+TARGET_SNOWFLAKE_S3_KEY_PREFIX=<bucket-directory>
+TARGET_SNOWFLAKE_STAGE=<stage-object-with-schema-name>
+TARGET_SNOWFLAKE_FILE_FORMAT=<file-format-object-with-schema-name>
+CLIENT_SIDE_ENCRYPTION_MASTER_KEY=<client_side_encryption_master_key>
+CLIENT_SIDE_ENCRYPTION_STAGE_OBJECT=<client_side_encryption_stage_object>

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,6 +1,8 @@
 import os
 import json
+from dotenv import load_dotenv
 
+load_dotenv()
 
 def get_db_config():
     config = {}
@@ -26,6 +28,7 @@ def get_db_config():
     config['aws_secret_access_key'] = os.environ.get('TARGET_SNOWFLAKE_AWS_SECRET_ACCESS_KEY')
     config['s3_bucket'] = os.environ.get('TARGET_SNOWFLAKE_S3_BUCKET')
     config['s3_key_prefix'] = os.environ.get('TARGET_SNOWFLAKE_S3_KEY_PREFIX')
+    config['s3_acl'] = os.environ.get('TARGET_SNOWFLAKE_S3_ACL')
 
     # External stage in snowflake with client side encryption details
     config['client_side_encryption_master_key'] = os.environ.get('CLIENT_SIDE_ENCRYPTION_MASTER_KEY')


### PR DESCRIPTION
## Changes

- Add `s3_acl: acl-name` to SF target config, so an object's ACL can be altered after uploading
- Add `.env` support for integration tests