### PR TITLE
Change log level when no primary key

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -351,7 +351,7 @@ class DbSync:
         try:
             key_props = [str(flatten[p]) for p in self.stream_schema_message['key_properties']]
         except Exception as exc:
-            self.logger.info("Cannot find {} primary key(s) in record: {}".format(self.stream_schema_message['key_properties'],
+            self.logger.error("Cannot find {} primary key(s) in record: {}".format(self.stream_schema_message['key_properties'],
                                                                      flatten))
             raise exc
         return ','.join(key_props)


### PR DESCRIPTION
Changing log level from `INFO` to `ERROR` when no primary key found.
This is useful if PPW configured to use alert handlers. The error will be extracted from the log and send in the alerts.


ATM when primary not found target-snowflake logs it as:
```
time=2020-07-22 14:32:49 logger_name=target_snowflake log_level=INFO message=Cannot find ['id'] primary key(s) in record: {"x": "abcd", "y": "abcd"}'
```

The `INFO` should be `ERROR` instead.