### PR TITLE
[AP-822] S3 profile based auth, session_token, AWS stage creds from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Full list of options in `config.json`:
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  | No         | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can upload files into specific directories in the S3 bucket. |
 | s3_endpoint_url                     | String  | No         | The complete URL to use for the constructed client. This is allowing to use non-native s3 account. |
+| s3_region_name                      | String  | No         | Default region when creating new connections |
 | s3_acl                              | String  | No         | S3 ACL name to set on the uploaded files                                                   |
 | stage                               | String  | Yes        | Named external stage name created at pre-requirements section. Has to be a fully qualified name including the schema name |
 | file_format                         | String  | Yes        | Named file format name created at pre-requirements section. Has to be a fully qualified name including the schema name. |

--- a/README.md
+++ b/README.md
@@ -131,12 +131,14 @@ Full list of options in `config.json`:
 | user                                | String  | Yes        | Snowflake User                                                |
 | password                            | String  | Yes        | Snowflake Password                                            |
 | warehouse                           | String  | Yes        | Snowflake virtual warehouse name                              |
-| aws_access_key_id                   | String  | No         | S3 Access Key Id. If not provided, AWS_ACCESS_KEY_ID environment variable or IAM role will be used |
-| aws_secret_access_key               | String  | No         | S3 Secret Access Key. If not provided, AWS_SECRET_ACCESS_KEY environment variable or IAM role will be used |
-| aws_session_token                   | String  | No         | AWS Session token. If not provided, AWS_SESSION_TOKEN environment variable will be used |
-| s3_acl                              | String  | No         | S3 ACL name                                                |
+| aws_access_key_id                   | String  | No         | S3 Access Key Id. If not provided, `AWS_ACCESS_KEY_ID` environment variable or IAM role will be used |
+| aws_secret_access_key               | String  | No         | S3 Secret Access Key. If not provided, `AWS_SECRET_ACCESS_KEY` environment variable or IAM role will be used |
+| aws_session_token                   | String  | No         | AWS Session token. If not provided, `AWS_SESSION_TOKEN` environment variable will be used |
+| aws_profile                         | String  | No         | AWS profile name for profile based authentication. If not provided, `AWS_PROFILE` environment variable will be used. |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  | No         | (Default: None) A static prefix before the generated S3 key names. Using prefixes you can upload files into specific directories in the S3 bucket. |
+| s3_endpoint_url                     | String  | No         | The complete URL to use for the constructed client. This is allowing to use non-native s3 account. |
+| s3_acl                              | String  | No         | S3 ACL name to set on the uploaded files                                                   |
 | stage                               | String  | Yes        | Named external stage name created at pre-requirements section. Has to be a fully qualified name including the schema name |
 | file_format                         | String  | Yes        | Named file format name created at pre-requirements section. Has to be a fully qualified name including the schema name. |
 | batch_size_rows                     | Integer |            | (Default: 100000) Maximum number of rows in each batch. At the end of each batch, the rows in the batch are loaded into Snowflake. |


### PR DESCRIPTION
This target is currently using hard coded `aws_access_key_id` and `aws_secret_access_key` to connect to S3 external stages. Instead of hard coded credentials we should be able to use env vars, AWS profile based authentication and IAM roles as alternative authentication methods when connecting to exteranal stage on S3.

This PR adds these features to this target.

* config.json: `aws_profile` -  Env var: `AWS_PROFILE`
* config.json: `aws_access_key_id` - Env var: `AWS_ACCESS_KEY_ID`
* config.json: `aws_secret_access_key` - Env var: `AWS_SECRET_ACCESS_KEY`
* config.json: `aws_session_token` - Env var: `AWS_SESSION_TOKEN`
* config.json: `s3_endpoint_url` - Allowing to use non-native s3 account
* config.json: `s3_region_name` - Region name when creating new connection

The target is using profile based authentication by default using the `default` AWS profile. The PR is fully backward compatible.