### PR TITLE
[AP-824] Set QUOTED_IDENTIFIERS_IGNORE_CASE session parameter to false

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -323,7 +323,11 @@ class DbSync:
             account=self.connection_config['account'],
             database=self.connection_config['dbname'],
             warehouse=self.connection_config['warehouse'],
-            autocommit=True
+            autocommit=True,
+            session_parameters={
+                # Quoted identifiers should be case sensitive
+                'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE'
+            }
         )
 
     def query(self, query, params=None, max_records=0):


### PR DESCRIPTION
This PR set  [QUOTED_IDENTIFIERS_IGNORE_CASE](https://docs.snowflake.com/en/sql-reference/parameters.html#quoted-identifiers-ignore-case) session parameter to `FALSE` when connecting to snowflake. This parameter can set for account, user and session and when it's not the default `FALSE` then target-snowflake fails.

**Problem**:  [QUOTED_IDENTIFIERS_IGNORE_CASE](https://docs.snowflake.com/en/sql-reference/parameters.html#quoted-identifiers-ignore-case) is a snowflake parameter that specifies whether the case of letters is ignored for all object identifiers in double quotes. Quoted identifiers expected as case sensitive values in multiple places, for example when creating columns with reserved words, versioning columns, getting column informations, etc. 

**To reproduce**:

1. `ALTER ACCOUNT|USER|SESSION ... SET QUOTED_IDENTIFIERS_IGNORE_CASE = TRUE`

2. Run target-snowflake and it fails error.


More info about the problem at
https://singer-io.slack.com/archives/CNL7DL597/p1596199391191200?thread_ts=1596194460.179100&cid=CNL7DL597