### PR TITLE
Bump Joblib to lastest version. Was failing on python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ singer-python==5.1.1
 snowflake-connector-python==2.0.3
 boto3==1.9.33
 inflection==0.3.1
-joblib==0.13.2
+joblib==0.16.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name="pipelinewise-target-snowflake",
           'botocore==1.13.8',
           'urllib3==1.24.3',
           'inflection==0.3.1',
-          'joblib==0.13.2',
+          'joblib==0.16.0',
           'python-dateutil==2.8.1'
       ],
       extras_require={


### PR DESCRIPTION
## Context

On python 3.8 it was causing this errror : 

`Traceback (most recent call last):
  File ".venv/pipelinewise-target-snowflake/bin/target-snowflake", line 11, in <module>
    load_entry_point('pipelinewise-target-snowflake', 'console_scripts', 'target-snowflake')()
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/pkg_resources/__init__.py", line 490, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2862, in load_entry_point
    return ep.load()
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2462, in load
    return self.resolve()
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2468, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File ".pipelinewise-target-snowflake/target_snowflake/__init__.py", line 18, in <module>
    from joblib import Parallel, delayed, parallel_backend
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/__init__.py", line 119, in <module>
    from .parallel import Parallel
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/parallel.py", line 28, in <module>
    from ._parallel_backends import (FallbackToBackend, MultiprocessingBackend,
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/_parallel_backends.py", line 22, in <module>
    from .executor import get_memmapping_executor
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/executor.py", line 14, in <module>
    from .externals.loky.reusable_executor import get_reusable_executor
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/externals/loky/__init__.py", line 12, in <module>
    from .backend.reduction import set_loky_pickler
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/externals/loky/backend/reduction.py", line 125, in <module>
    from joblib.externals import cloudpickle  # noqa: F401
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/externals/cloudpickle/__init__.py", line 3, in <module>
    from .cloudpickle import *
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/externals/cloudpickle/cloudpickle.py", line 152, in <module>
    _cell_set_template_code = _make_cell_set_template_code()
  File ".venv/pipelinewise-target-snowflake/lib/python3.8/site-packages/joblib/externals/cloudpickle/cloudpickle.py", line 133, in _make_cell_set_template_code
    return types.CodeType(
TypeError: an integer is required (got type bytes)`

### Changes

Bump Joblib to talest version. 

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
