### PR TITLE
Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Prepare the data as '...'
+2. Run the command '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Your environment**
+ - Version of target: [e.g. 2.0.0]
+ - Version of python [e.g. 3.8]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/QUESTION.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Ask anything about this project
+title: ''
+labels: help wanted
+assignees: ''
+
+---
+
+**Your question**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PipelineWise Community Slack channel
+    url: https://singer-io.slack.com/messages/pipelinewise
+    about: Open discussion about PipelineWise

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Problem
+
+_Describe the problem your PR is trying to solve_
+
+## Proposed changes
+
+_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
+If it fixes a bug or resolves a feature request, be sure to link to that issue._
+
+
+## Types of changes
+
+What types of changes does your code introduce to PipelineWise?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
+
+## Checklist
+
+- [ ] Description above provides context of the change
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] Unit tests for changes (not needed for documentation changes)
+- [ ] CI checks pass with my changes
+- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
+- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
+- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
+- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
+- [ ] Relevant documentation is updated including usage instructions


### PR DESCRIPTION
## Context

No github templates in this repo and new issues and PRs pop up the not applicable default TW template.

### Changes

Adding github templates:
* Pull Request template
* Issue templates:
    - 3 issue types, (bug, feature request and question), 
    - Issues are automatically labelled to make further issue analysis easier.
    - TW default template to **Report a security vulnerability**, that is required for every public, open source TransferWise project. You can find an example [here](https://github.com/transferwise/pipelinewise-tap-google-analytics/security/policy). This should be available in every public repo.
    - Link to the community slack channel for open discussion

This PR makes the issues page to look like this when somebody raises an issue: 

<img width="1451" alt="Screenshot 2020-09-22 at 13 18 22" src="https://user-images.githubusercontent.com/643687/93880946-23ad9200-fcd6-11ea-807b-88e1ce372ee9.png">
