### PR TITLE
[AP-866] Add query_tag config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Full list of options in `config.json`:
 | validate_records                    | Boolean |            | (Default: False) Validate every single record message to the corresponding JSON schema. This option is disabled by default and invalid RECORD messages will fail only at load time by Snowflake. Enabling this option will detect invalid records earlier but could cause performance degradation. |
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
 | no_compression                      | Boolean |            | (Default: False) Generate uncompressed CSV files when loading to Snowflake. Normally, by default GZIP compressed files are generated. |
+| query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `schema` and `table` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
 
 ### To run tests:
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -366,7 +366,7 @@ class DbSync:
                 'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',
                 'QUERY_TAG': create_query_tag(self.connection_config.get('query_tag'),
                                               schema=self.schema_name,
-                                              table=self.table_name(stream, False))
+                                              table=self.table_name(stream, False, True))
             }
         )
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -190,6 +190,39 @@ def stream_name_to_dict(stream_name, separator='-'):
         'table_name': table_name
     }
 
+
+def create_query_tag(query_tag_pattern: str, schema: str = None, table: str = None) -> str:
+    """
+    Generate a string to tag executed queries in Snowflake.
+    Replaces tokens `schema` and `table` with the appropriate values.
+
+    Example with tokens:
+        'Loading data into {schema}.{table}'
+
+    Args:
+        query_tag_pattern:
+        schema: optional value to replace {schema} token in query_tag_pattern
+        table: optional value to replace {table} token in query_tag_pattern
+
+    Returns:
+        String if query_tag_patter defined otherwise None
+    """
+    if not query_tag_pattern:
+        return None
+
+    query_tag = query_tag_pattern
+
+    # replace tokens
+    for k, v in {
+        '{schema}': schema or 'unknown-schema',
+        '{table}': table or 'unknown-table'
+    }.items():
+        if k in query_tag:
+            query_tag = query_tag.replace(k, v)
+
+    return query_tag
+
+
 # pylint: disable=too-many-public-methods,too-many-instance-attributes
 class DbSync:
     def __init__(self, connection_config, stream_schema_message=None, table_cache=None):
@@ -317,6 +350,10 @@ class DbSync:
                                   endpoint_url=config.get('s3_endpoint_url'))
 
     def open_connection(self):
+        stream = None
+        if self.stream_schema_message:
+            stream = self.stream_schema_message['stream']
+
         return snowflake.connector.connect(
             user=self.connection_config['user'],
             password=self.connection_config['password'],
@@ -326,7 +363,10 @@ class DbSync:
             autocommit=True,
             session_parameters={
                 # Quoted identifiers should be case sensitive
-                'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE'
+                'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',
+                'QUERY_TAG': create_query_tag(self.connection_config.get('query_tag'),
+                                              schema=self.schema_name,
+                                              table=self.table_name(stream, False))
             }
         )
 
@@ -357,6 +397,9 @@ class DbSync:
         return result
 
     def table_name(self, stream_name, is_temporary, without_schema = False):
+        if not stream_name:
+            return None
+
         stream_dict = stream_name_to_dict(stream_name)
         table_name = stream_dict['table_name']
         sf_table_name = table_name.replace('.', '_').replace('-', '_').lower()

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1057,16 +1057,17 @@ class TestIntegration(unittest.TestCase):
                                  f"WHERE query_tag like '%PPW test tap run at {current_time}%'"
                                  "GROUP BY query_tag "
                                  "ORDER BY 1")
+        target_schema = self.config['default_target_schema']
         self.assertEqual(result, [{
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into test_pk.test_pk."TEST_TABLE_ONE"',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}."TEST_TABLE_ONE"',
             'QUERIES': 12
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into test_pk.test_pk."TEST_TABLE_THREE"',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}."TEST_TABLE_THREE"',
             'QUERIES': 10
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into test_pk.test_pk."TEST_TABLE_TWO"',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}."TEST_TABLE_TWO"',
             'QUERIES': 10
             },
             {

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1040,3 +1040,37 @@ class TestIntegration(unittest.TestCase):
 
         # Reset parameters default
         snowflake.query(f"ALTER USER {self.config['user']} UNSET QUOTED_IDENTIFIERS_IGNORE_CASE")
+
+    def test_query_tagging(self):
+        """Loading multiple tables with query tagging"""
+        snowflake = DbSync(self.config)
+        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+        current_time = datetime.datetime.now().strftime('%H:%M:%s')
+
+        # Tag queries with dynamic schema and table tokens
+        self.config['query_tag'] = f'PPW test tap run at {current_time}. Loading into {{schema}}.{{table}}'
+        self.persist_lines_with_cache(tap_lines)
+
+        # Get query tags from QUERY_HISTORY
+        result = snowflake.query("SELECT query_tag, count(*) queries "
+                                 f"FROM table(information_schema.query_history_by_user('{self.config['user']}')) "
+                                 f"WHERE query_tag like '%PPW test tap run at {current_time}%'"
+                                 "GROUP BY query_tag "
+                                 "ORDER BY 1")
+        self.assertEqual(result, [{
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into test_pk.test_pk."TEST_TABLE_ONE"',
+            'QUERIES': 12
+            },
+            {
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into test_pk.test_pk."TEST_TABLE_THREE"',
+            'QUERIES': 10
+            },
+            {
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into test_pk.test_pk."TEST_TABLE_TWO"',
+            'QUERIES': 10
+            },
+            {
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into unknown-schema.unknown-table',
+            'QUERIES': 4
+            }
+        ])

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -355,3 +355,13 @@ class TestDBSync(unittest.TestCase):
         for idx, (should_use_flatten_schema, record, expected_output) in enumerate(test_cases):
             output = flatten_record(record, flatten_schema if should_use_flatten_schema else None)
             self.assertEqual(output, expected_output, f"Test {idx} failed. Testcase: {test_cases[idx]}")
+
+    def test_create_query_tag(self):
+        assert db_sync.create_query_tag(None) is None
+        assert db_sync.create_query_tag('This is a test query tag') == 'This is a test query tag'
+        assert db_sync.create_query_tag('Loading into {schema}.{table}',
+                                        schema='test_schema',
+                                        table='test_table') == 'Loading into test_schema.test_table'
+        assert db_sync.create_query_tag('Loading into {schema}.{table}',
+                                        schema=None,
+                                        table=None) == 'Loading into unknown-schema.unknown-table'


### PR DESCRIPTION
## Problem

Sometimes it's needed to analyse queries in Snowflake that was created by this target connector. `QUERY_HISTORY` snowflake views keep all the queries but hard to link them back to the target, especially when the same target used by multiple taps.

## Proposed changes

Introducing `query_tag` optional config property to tag executed queries in Snowflake. Replaces tokens `schema` and `table` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions.

The main PipelineWise will generate the `query_tag` automatically for every snowflake targets including the `tap_id`, and this target will add the target `schema` and target `table` dynamically. 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions