### PR TITLE
[AP-866] Add database token to query_tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Full list of options in `config.json`:
 | validate_records                    | Boolean |            | (Default: False) Validate every single record message to the corresponding JSON schema. This option is disabled by default and invalid RECORD messages will fail only at load time by Snowflake. Enabling this option will detect invalid records earlier but could cause performance degradation. |
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
 | no_compression                      | Boolean |            | (Default: False) Generate uncompressed CSV files when loading to Snowflake. Normally, by default GZIP compressed files are generated. |
-| query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `schema` and `table` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
+| query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `{database}`, `schema` and `{table}` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
 
 ### To run tests:
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Full list of options in `config.json`:
 | validate_records                    | Boolean |            | (Default: False) Validate every single record message to the corresponding JSON schema. This option is disabled by default and invalid RECORD messages will fail only at load time by Snowflake. Enabling this option will detect invalid records earlier but could cause performance degradation. |
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
 | no_compression                      | Boolean |            | (Default: False) Generate uncompressed CSV files when loading to Snowflake. Normally, by default GZIP compressed files are generated. |
-| query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `{database}`, `{schema}` and `{table}` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
+| query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `{{database}}`, `{{schema}}` and `{{table}}` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
 
 ### To run tests:
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Full list of options in `config.json`:
 | validate_records                    | Boolean |            | (Default: False) Validate every single record message to the corresponding JSON schema. This option is disabled by default and invalid RECORD messages will fail only at load time by Snowflake. Enabling this option will detect invalid records earlier but could cause performance degradation. |
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
 | no_compression                      | Boolean |            | (Default: False) Generate uncompressed CSV files when loading to Snowflake. Normally, by default GZIP compressed files are generated. |
-| query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `{database}`, `schema` and `{table}` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
+| query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `{database}`, `{schema}` and `{table}` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
 
 ### To run tests:
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -226,9 +226,9 @@ def create_query_tag(query_tag_pattern: str, database: str = None, schema: str =
 
     Args:
         query_tag_pattern:
-        database: optional value to replace {database} token in query_tag_pattern
-        schema: optional value to replace {schema} token in query_tag_pattern
-        table: optional value to replace {table} token in query_tag_pattern
+        database: optional value to replace {{database}} token in query_tag_pattern
+        schema: optional value to replace {{schema}} token in query_tag_pattern
+        table: optional value to replace {{table}} token in query_tag_pattern
 
     Returns:
         String if query_tag_patter defined otherwise None
@@ -240,9 +240,9 @@ def create_query_tag(query_tag_pattern: str, database: str = None, schema: str =
 
     # replace tokens, taking care of json formatted value compatibility
     for k, v in {
-        '{database}': json.dumps(database.strip('"')).strip('"') if database else None,
-        '{schema}': json.dumps(schema.strip('"')).strip('"') if schema else None,
-        '{table}': json.dumps(table.strip('"')).strip('"') if table else None
+        '{{database}}': json.dumps(database.strip('"')).strip('"') if database else None,
+        '{{schema}}': json.dumps(schema.strip('"')).strip('"') if schema else None,
+        '{{table}}': json.dumps(table.strip('"')).strip('"') if table else None
     }.items():
         if k in query_tag:
             query_tag = query_tag.replace(k, v or '')

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -237,13 +237,13 @@ def create_query_tag(query_tag_pattern: str, schema: str = None, table: str = No
 
     query_tag = query_tag_pattern
 
-    # replace tokens
+    # replace tokens, taking care of json formatted value compatibility
     for k, v in {
-        '{schema}': schema or 'unknown-schema',
-        '{table}': table or 'unknown-table'
+        '{schema}': json.dumps(schema)[1:-1] if schema else None,
+        '{table}': json.dumps(table)[1:-1] if table else None
     }.items():
         if k in query_tag:
-            query_tag = query_tag.replace(k, v)
+            query_tag = query_tag.replace(k, v or '')
 
     return query_tag
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -376,8 +376,8 @@ class DbSync:
                 # Quoted identifiers should be case sensitive
                 'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',
                 'QUERY_TAG': create_query_tag(self.connection_config.get('query_tag'),
-                                              schema=self.schema_name,
-                                              table=self.table_name(stream, False, True))
+                                              schema=self.schema_name.strip('"'),
+                                              table=self.table_name(stream, False, True).strip('"'))
             }
         )
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -239,8 +239,8 @@ def create_query_tag(query_tag_pattern: str, schema: str = None, table: str = No
 
     # replace tokens, taking care of json formatted value compatibility
     for k, v in {
-        '{schema}': json.dumps(schema)[1:-1] if schema else None,
-        '{table}': json.dumps(table)[1:-1] if table else None
+        '{schema}': json.dumps(schema.strip('"')).strip('"') if schema else None,
+        '{table}': json.dumps(table.strip('"')).strip('"') if table else None
     }.items():
         if k in query_tag:
             query_tag = query_tag.replace(k, v or '')
@@ -376,8 +376,8 @@ class DbSync:
                 # Quoted identifiers should be case sensitive
                 'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',
                 'QUERY_TAG': create_query_tag(self.connection_config.get('query_tag'),
-                                              schema=self.schema_name.strip('"'),
-                                              table=self.table_name(stream, False, True).strip('"'))
+                                              schema=self.schema_name,
+                                              table=self.table_name(stream, False, True))
             }
         )
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -216,7 +216,7 @@ def stream_name_to_dict(stream_name, separator='-'):
     }
 
 
-def create_query_tag(query_tag_pattern: str, schema: str = None, table: str = None) -> str:
+def create_query_tag(query_tag_pattern: str, database: str = None, schema: str = None, table: str = None) -> str:
     """
     Generate a string to tag executed queries in Snowflake.
     Replaces tokens `schema` and `table` with the appropriate values.
@@ -226,6 +226,7 @@ def create_query_tag(query_tag_pattern: str, schema: str = None, table: str = No
 
     Args:
         query_tag_pattern:
+        database: optional value to replace {database} token in query_tag_pattern
         schema: optional value to replace {schema} token in query_tag_pattern
         table: optional value to replace {table} token in query_tag_pattern
 
@@ -239,6 +240,7 @@ def create_query_tag(query_tag_pattern: str, schema: str = None, table: str = No
 
     # replace tokens, taking care of json formatted value compatibility
     for k, v in {
+        '{database}': json.dumps(database.strip('"')).strip('"') if database else None,
         '{schema}': json.dumps(schema.strip('"')).strip('"') if schema else None,
         '{table}': json.dumps(table.strip('"')).strip('"') if table else None
     }.items():
@@ -376,6 +378,7 @@ class DbSync:
                 # Quoted identifiers should be case sensitive
                 'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',
                 'QUERY_TAG': create_query_tag(self.connection_config.get('query_tag'),
+                                              database=self.connection_config['dbname'],
                                               schema=self.schema_name,
                                               table=self.table_name(stream, False, True))
             }

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1050,7 +1050,8 @@ class TestIntegration(unittest.TestCase):
         current_time = datetime.datetime.now().strftime('%H:%M:%s')
 
         # Tag queries with dynamic schema and table tokens
-        self.config['query_tag'] = f'PPW test tap run at {current_time}. Loading into {{database}}.{{schema}}.{{table}}'
+        self.config['query_tag'] = f'PPW test tap run at {current_time}. ' \
+                                   f'Loading into {{{{database}}}}.{{{{schema}}}}.{{{{table}}}}'
         self.persist_lines_with_cache(tap_lines)
 
         # Get query tags from QUERY_HISTORY

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1061,19 +1061,19 @@ class TestIntegration(unittest.TestCase):
                                  "ORDER BY 1")
         target_schema = self.config['default_target_schema']
         self.assertEqual(result, [{
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}."TEST_TABLE_ONE"',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}.TEST_TABLE_ONE',
             'QUERIES': 12
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}."TEST_TABLE_THREE"',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}.TEST_TABLE_THREE',
             'QUERIES': 10
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}."TEST_TABLE_TWO"',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}.TEST_TABLE_TWO',
             'QUERIES': 10
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into unknown-schema.unknown-table',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into .',
             'QUERIES': 4
             }
         ])

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1050,7 +1050,7 @@ class TestIntegration(unittest.TestCase):
         current_time = datetime.datetime.now().strftime('%H:%M:%s')
 
         # Tag queries with dynamic schema and table tokens
-        self.config['query_tag'] = f'PPW test tap run at {current_time}. Loading into {{schema}}.{{table}}'
+        self.config['query_tag'] = f'PPW test tap run at {current_time}. Loading into {{database}}.{{schema}}.{{table}}'
         self.persist_lines_with_cache(tap_lines)
 
         # Get query tags from QUERY_HISTORY
@@ -1059,21 +1059,22 @@ class TestIntegration(unittest.TestCase):
                                  f"WHERE query_tag like '%PPW test tap run at {current_time}%'"
                                  "GROUP BY query_tag "
                                  "ORDER BY 1")
+        target_db = self.config['dbname']
         target_schema = self.config['default_target_schema']
         self.assertEqual(result, [{
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into .',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}..',
             'QUERIES': 4
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}.TEST_TABLE_ONE',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_ONE',
             'QUERIES': 12
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}.TEST_TABLE_THREE',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_THREE',
             'QUERIES': 10
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}.TEST_TABLE_TWO',
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_TWO',
             'QUERIES': 10
             }
         ])

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1061,6 +1061,10 @@ class TestIntegration(unittest.TestCase):
                                  "ORDER BY 1")
         target_schema = self.config['default_target_schema']
         self.assertEqual(result, [{
+            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into .',
+            'QUERIES': 4
+            },
+            {
             'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}.TEST_TABLE_ONE',
             'QUERIES': 12
             },
@@ -1071,10 +1075,6 @@ class TestIntegration(unittest.TestCase):
             {
             'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_schema}.TEST_TABLE_TWO',
             'QUERIES': 10
-            },
-            {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into .',
-            'QUERIES': 4
             }
         ])
 

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -405,6 +405,6 @@ class TestDBSync(unittest.TestCase):
                                                   table='"test_table"')
         # Load the generated JSON formatted query tag to make sure it's a valid JSON
         assert json.loads(json_query_tag) == {
-            'schema': '"test_schema"',
-            'table': '"test_table"'
+            'schema': 'test_schema',
+            'table': 'test_table'
         }

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -372,39 +372,51 @@ class TestDBSync(unittest.TestCase):
     def test_create_query_tag(self):
         assert db_sync.create_query_tag(None) is None
         assert db_sync.create_query_tag('This is a test query tag') == 'This is a test query tag'
-        assert db_sync.create_query_tag('Loading into {schema}.{table}',
+        assert db_sync.create_query_tag('Loading into {database}.{schema}.{table}',
+                                        database='test_database',
                                         schema='test_schema',
-                                        table='test_table') == 'Loading into test_schema.test_table'
-        assert db_sync.create_query_tag('Loading into {schema}.{table}',
+                                        table='test_table') == 'Loading into test_database.test_schema.test_table'
+        assert db_sync.create_query_tag('Loading into {database}.{schema}.{table}',
+                                        database=None,
                                         schema=None,
-                                        table=None) == 'Loading into .'
+                                        table=None) == 'Loading into ..'
 
         # JSON formatted query tags with variables
-        json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
-                                                  schema='test_schema',
-                                                  table='test_table')
+        json_query_tag = db_sync.create_query_tag(
+            '{"database": "{database}", "schema": "{schema}", "table": "{table}"}',
+            database='test_database',
+            schema='test_schema',
+            table='test_table')
         # Load the generated JSON formatted query tag to make sure it's a valid JSON
         assert json.loads(json_query_tag) == {
+            'database': 'test_database',
             'schema': 'test_schema',
             'table': 'test_table'
         }
 
         # JSON formatted query tags with variables quotes in the middle
-        json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
-                                                  schema='test"schema',
-                                                  table='test"table')
+        json_query_tag = db_sync.create_query_tag(
+            '{"database": "{database}", "schema": "{schema}", "table": "{table}"}',
+            database='test"database',
+            schema='test"schema',
+            table='test"table')
+
         # Load the generated JSON formatted query tag to make sure it's a valid JSON
         assert json.loads(json_query_tag) == {
+            'database': 'test"database',
             'schema': 'test"schema',
             'table': 'test"table'
         }
 
         # JSON formatted query tags with quoted variables
-        json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
-                                                  schema='"test_schema"',
-                                                  table='"test_table"')
+        json_query_tag = db_sync.create_query_tag(
+            '{"database": "{database}", "schema": "{schema}", "table": "{table}"}',
+            database='"test_database"',
+            schema='"test_schema"',
+            table='"test_table"')
         # Load the generated JSON formatted query tag to make sure it's a valid JSON
         assert json.loads(json_query_tag) == {
+            'database': 'test_database',
             'schema': 'test_schema',
             'table': 'test_table'
         }

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 
 from target_snowflake import db_sync
 
@@ -376,4 +377,22 @@ class TestDBSync(unittest.TestCase):
                                         table='test_table') == 'Loading into test_schema.test_table'
         assert db_sync.create_query_tag('Loading into {schema}.{table}',
                                         schema=None,
-                                        table=None) == 'Loading into unknown-schema.unknown-table'
+                                        table=None) == 'Loading into .'
+
+        # JSON formatted query tags with variables
+        json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
+                                                  schema='test_schema',
+                                                  table='test_table')
+        assert json.loads(json_query_tag) == {
+            'schema': 'test_schema',
+            'table': 'test_table'
+        }
+
+        # JSON formatted query tags with quoted variables
+        json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
+                                                  schema='"test_schema"',
+                                                  table='"test_table"')
+        assert json.loads(json_query_tag) == {
+            'schema': '"test_schema"',
+            'table': '"test_table"'
+        }

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -383,6 +383,7 @@ class TestDBSync(unittest.TestCase):
         json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
                                                   schema='test_schema',
                                                   table='test_table')
+        # Load the generated JSON formatted query tag to make sure it's a valid JSON
         assert json.loads(json_query_tag) == {
             'schema': 'test_schema',
             'table': 'test_table'
@@ -392,6 +393,7 @@ class TestDBSync(unittest.TestCase):
         json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
                                                   schema='"test_schema"',
                                                   table='"test_table"')
+        # Load the generated JSON formatted query tag to make sure it's a valid JSON
         assert json.loads(json_query_tag) == {
             'schema': '"test_schema"',
             'table': '"test_table"'

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -389,6 +389,16 @@ class TestDBSync(unittest.TestCase):
             'table': 'test_table'
         }
 
+        # JSON formatted query tags with variables quotes in the middle
+        json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
+                                                  schema='test"schema',
+                                                  table='test"table')
+        # Load the generated JSON formatted query tag to make sure it's a valid JSON
+        assert json.loads(json_query_tag) == {
+            'schema': 'test"schema',
+            'table': 'test"table'
+        }
+
         # JSON formatted query tags with quoted variables
         json_query_tag = db_sync.create_query_tag('{"schema": "{schema}", "table": "{table}"}',
                                                   schema='"test_schema"',

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -372,18 +372,18 @@ class TestDBSync(unittest.TestCase):
     def test_create_query_tag(self):
         assert db_sync.create_query_tag(None) is None
         assert db_sync.create_query_tag('This is a test query tag') == 'This is a test query tag'
-        assert db_sync.create_query_tag('Loading into {database}.{schema}.{table}',
+        assert db_sync.create_query_tag('Loading into {{database}}.{{schema}}.{{table}}',
                                         database='test_database',
                                         schema='test_schema',
                                         table='test_table') == 'Loading into test_database.test_schema.test_table'
-        assert db_sync.create_query_tag('Loading into {database}.{schema}.{table}',
+        assert db_sync.create_query_tag('Loading into {{database}}.{{schema}}.{{table}}',
                                         database=None,
                                         schema=None,
                                         table=None) == 'Loading into ..'
 
         # JSON formatted query tags with variables
         json_query_tag = db_sync.create_query_tag(
-            '{"database": "{database}", "schema": "{schema}", "table": "{table}"}',
+            '{"database": "{{database}}", "schema": "{{schema}}", "table": "{{table}}"}',
             database='test_database',
             schema='test_schema',
             table='test_table')
@@ -396,7 +396,7 @@ class TestDBSync(unittest.TestCase):
 
         # JSON formatted query tags with variables quotes in the middle
         json_query_tag = db_sync.create_query_tag(
-            '{"database": "{database}", "schema": "{schema}", "table": "{table}"}',
+            '{"database": "{{database}}", "schema": "{{schema}}", "table": "{{table}}"}',
             database='test"database',
             schema='test"schema',
             table='test"table')
@@ -410,7 +410,7 @@ class TestDBSync(unittest.TestCase):
 
         # JSON formatted query tags with quoted variables
         json_query_tag = db_sync.create_query_tag(
-            '{"database": "{database}", "schema": "{schema}", "table": "{table}"}',
+            '{"database": "{{database}}", "schema": "{{schema}}", "table": "{{table}}"}',
             database='"test_database"',
             schema='"test_schema"',
             table='"test_table"')


### PR DESCRIPTION
## Problem

This PR adds `{database}` token to `query_tag` template. The value evaluated at runtime and replaced to the actual database name.

The PR adds a few more test cases as well and fixes an edge case with JSON formatted `query_tags` with quotes.

## Proposed changes

Replace template variables with JSON compatible, quote escaped values.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions