### PR TITLE
Replace usage of LAST_QUERY_ID with query id from cursor

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -409,15 +409,12 @@ class DbSync:
 
         with self.open_connection() as connection:
             with connection.cursor(snowflake.connector.DictCursor) as cur:
-                queries = []
 
                 # Run every query in one transaction if query is a list of SQL
                 if type(query) is list:
                     self.logger.info('Starting Transaction')
                     cur.execute("START TRANSACTION")
-
                     queries = query
-
                 else:
                     queries = [query]
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -415,6 +415,9 @@ class DbSync:
                 if type(query) is list:
                     self.logger.info('Starting Transaction')
                     cur.execute("START TRANSACTION")
+
+                    queries = query
+
                 else:
                     queries = [query]
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -397,7 +397,7 @@ class DbSync:
             }
         )
 
-    def query(self, query: Union[str, List[str]], params: Dict = None, max_records=0, safe_to_log=True) -> List[Dict]:
+    def query(self, query: Union[str, List[str]], params: Dict = None, max_records=0) -> List[Dict]:
         result = []
 
         if params is None:
@@ -421,11 +421,12 @@ class DbSync:
                 qid = None
 
                 for q in queries:
-                    if safe_to_log:
-                        self.logger.info("Running query: %s", q)
 
                     # update the LAST_QID
                     params['LAST_QID'] = qid
+
+                    self.logger.info("Running query: '%s' with Params %s", q, params)
+
                     cur.execute(q, params)
                     qid = cur.sfqid
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -413,15 +413,14 @@ class DbSync:
 
                 # Run every query in one transaction if query is a list of SQL
                 if type(query) is list:
-                    queries.append("START TRANSACTION")
-                    queries.extend(query)
+                    self.logger.info('Starting Transaction')
+                    cur.execute("START TRANSACTION")
                 else:
                     queries = [query]
 
                 qid = None
 
                 for q in queries:
-
                     if safe_to_log:
                         self.logger.info("Running query: %s", q)
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -1,5 +1,7 @@
 import json
 import sys
+from typing import Tuple, List, Dict, Optional
+
 import snowflake.connector
 import collections
 import inflection
@@ -395,8 +397,9 @@ class DbSync:
             }
         )
 
-    def query(self, query, params=None, max_records=0):
+    def query(self, query, params=None, max_records=0, safe_to_log=False) -> List[Dict]:
         result = []
+
         with self.open_connection() as connection:
             with connection.cursor(snowflake.connector.DictCursor) as cur:
                 queries = []
@@ -408,9 +411,17 @@ class DbSync:
                 else:
                     queries = [query]
 
+                qid = None
+
                 for q in queries:
-                    self.logger.debug("Running query: {}".format(q))
+                    # support for a QID name parameter in case we want to pass the last query id to the current query
+                    q = q.format(QID=qid)
+
+                    if safe_to_log:
+                        self.logger.info("Running query: %s", q)
+
                     cur.execute(q, params)
+                    qid = cur.sfqid
 
                     # Raise exception if returned rows greater than max allowed records
                     if 0 < max_records < cur.rowcount:
@@ -634,20 +645,20 @@ class DbSync:
             for schema in table_schemas:
                 queries = []
 
-                # Get column data types by SHOW COLUMNS
+                # Get tables in schema
                 show_tables = f"SHOW TERSE TABLES IN SCHEMA {self.connection_config['dbname']}.{schema}"
 
                 # Convert output of SHOW TABLES to table
-                select = f"""
+                select = """
                     SELECT "schema_name" AS schema_name
                           ,"name"        AS table_name
-                      FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))
+                      FROM TABLE(RESULT_SCAN('{QID}'))
                 """
                 queries.extend([show_tables, select])
 
                 # Run everything in one transaction
                 try:
-                    tables = self.query(queries, max_records=9999)
+                    tables = self.query(queries, max_records=9999, safe_to_log=True)
 
                 # Catch exception when schema not exists and SHOW TABLES throws a ProgrammingError
                 # Regexp to extract snowflake error code and message from the exception message
@@ -672,30 +683,36 @@ class DbSync:
                 show_columns = f"SHOW COLUMNS IN SCHEMA {self.connection_config['dbname']}.{schema}"
 
                 # Convert output of SHOW COLUMNS to table and insert results into the cache COLUMNS table
-                select = f"""
+                #
+                # ----------------------------------------------------------------------------------------
+                # Character and numeric columns display their generic data type rather than their defined
+                # data type (i.e. TEXT for all character types, FIXED for all fixed-point numeric types,
+                # and REAL for all floating-point numeric types).
+                # Further info at https://docs.snowflake.net/manuals/sql-reference/sql/show-columns.html
+                # ----------------------------------------------------------------------------------------
+                select = """
                     SELECT "schema_name" AS schema_name
                           ,"table_name"  AS table_name
                           ,"column_name" AS column_name
-                          -- ----------------------------------------------------------------------------------------
-                          -- Character and numeric columns display their generic data type rather than their defined
-                          -- data type (i.e. TEXT for all character types, FIXED for all fixed-point numeric types,
-                          -- and REAL for all floating-point numeric types).
-                          --
-                          -- Further info at https://docs.snowflake.net/manuals/sql-reference/sql/show-columns.html
-                          -- ----------------------------------------------------------------------------------------
                           ,CASE PARSE_JSON("data_type"):type::varchar
                              WHEN 'FIXED' THEN 'NUMBER'
                              WHEN 'REAL'  THEN 'FLOAT'
                              ELSE PARSE_JSON("data_type"):type::varchar
                            END data_type
-                      FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))
+                      FROM TABLE(RESULT_SCAN('{QID}'))
                 """
+
                 queries.extend([show_columns, select])
 
                 # Run everything in one transaction
                 try:
-                    columns = self.query(queries, max_records=9999)
-                    table_columns.extend(columns)
+                    columns = self.query(queries, max_records=9999, safe_to_log=True)
+
+                    if not columns:
+                        self.logger.warning('No columns discovered in the schema "%s"',
+                                            f"{self.connection_config['dbname']}.{schema}")
+                    else:
+                        table_columns.extend(columns)
 
                 # Catch exception when schema not exists and SHOW COLUMNS throws a ProgrammingError
                 # Regexp to extract snowflake error code and message from the exception message

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -404,8 +404,8 @@ class DbSync:
             params = {}
         else:
             if 'LAST_QID' in params:
-                self.logger.warning('LAST_QID is a reserved prepared statement parameter name, it will be used '
-                                    'once but will be overridden with each executed query!')
+                self.logger.warning('LAST_QID is a reserved prepared statement parameter name, '
+                                    'it will be overridden with each executed query!')
 
         with self.open_connection() as connection:
             with connection.cursor(snowflake.connector.DictCursor) as cur:
@@ -418,8 +418,7 @@ class DbSync:
                 else:
                     queries = [query]
 
-                # get the LAST_QID from params in case an initial value exists
-                qid = params.get('LAST_QID')
+                qid = None
 
                 for q in queries:
 

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1055,11 +1055,12 @@ class TestIntegration(unittest.TestCase):
         self.persist_lines_with_cache(tap_lines)
 
         # Get query tags from QUERY_HISTORY
-        result = snowflake.query("SELECT query_tag, count(*) queries "
-                                 f"FROM table(information_schema.query_history_by_user('{self.config['user']}')) "
-                                 f"WHERE query_tag like '%PPW test tap run at {current_time}%'"
-                                 "GROUP BY query_tag "
-                                 "ORDER BY 1")
+        result = snowflake.query(f"""SELECT query_tag, count(*) queries
+                                 FROM table(information_schema.query_history_by_user('{self.config['user']}'))
+                                 WHERE query_tag like '%%PPW test tap run at {current_time}%%'
+                                 GROUP BY query_tag
+                                 ORDER BY 1""")
+
         target_db = self.config['dbname']
         target_schema = self.config['default_target_schema']
         self.assertEqual(result, [{


### PR DESCRIPTION
## Problem

There seems to be an intermittent issue when running a list of query using `DBSync.query` method, the order in Snowflake history shows that Start transaction is the second instead of first, this messes up with queries that rely on `LAST_QUERY_ID()` results. for example the `select .. from TABLE(RESULT_SCAN(LAST_QUERY_ID()))` fails with:
```
SQL compilation error: error line 1 at position 7 invalid identifier '"schema_name"'
```

## Proposed changes

* Force start transaction first but running it outside of the loop.

* To reduce the dynamic nature of `select .. from TABLE(RESULT_SCAN(LAST_QUERY_ID()));`,  make use of the SF connector cursor ability to return the query id with the attribute `sfqid` and then pass it to the next query in the list as a named parameter.
* A reserved prepared statement param `LAST_QID` is introduced.

* Added few logs.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions