### PR TITLE
Parsing dates: Add checks and logs

### DIFF
--- a/tests/integration/resources/messages-with-unexpected-types.json
+++ b/tests/integration/resources/messages-with-unexpected-types.json
@@ -1,0 +1,8 @@
+{"type": "SCHEMA", "stream": "db-table_1", "schema": {"properties": {"c_pk": {"inclusion": "automatic", "minimum": -2147483648, "maximum": 2147483647, "type": ["null", "integer"]}, "c_time": {"format": "time", "inclusion": "available", "type": ["null", "string"]}}, "type": "object"}, "key_properties": ["c_pk"]}
+{"type": "ACTIVATE_VERSION", "stream": "db-table_1", "version": 2}
+{"type": "RECORD", "stream": "db-table_1", "record": {"c_pk": 1, "c_time": "04:00:00"}, "version": 2, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "RECORD", "stream": "db-table_1", "record": {"c_pk": 2, "c_time": "07:15:00"}, "version": 2, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "RECORD", "stream": "db-table_1", "record": {"c_pk": 3, "c_time": 235667, "_sdc_deleted_at": "2019-02-10T15:51:50.215998Z"}, "version": 2, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "STATE", "value": {"currently_syncing": "db-table_1", "bookmarks": {}}}
+{"type": "ACTIVATE_VERSION", "stream": "db-table_1", "version": 2}
+{"type": "STATE", "value": {"currently_syncing": null, "bookmarks": {"db-table_1": {"initial_full_table_complete": true}}}}

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1103,3 +1103,10 @@ class TestIntegration(unittest.TestCase):
         # 250001 (08001): Role 'INVALID-ROLE' specified in the connect string does not exist or not authorized.
         with assert_raises(DatabaseError):
             self.persist_lines_with_cache(tap_lines)
+
+    def test_parsing_date_failure(self):
+        """Test if custom role can be used"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-unexpected-types.json')
+
+        with assert_raises(target_snowflake.UnexpectedValueTypeException):
+            self.persist_lines_with_cache(tap_lines)

--- a/tests/unit/test_target_snowflake.py
+++ b/tests/unit/test_target_snowflake.py
@@ -4,6 +4,7 @@ import gzip
 import tempfile
 
 from unittest.mock import patch
+from nose.tools import assert_raises
 
 import target_snowflake
 
@@ -63,7 +64,7 @@ class TestTargetSnowflake(unittest.TestCase):
             'key3': '10000-01-22 12:04:22',
             'key4': '25:01:01',
             'key5': 'I\'m good',
-            'key6': None
+            'key6': None,
         }
 
         schema = {
@@ -106,6 +107,21 @@ class TestTargetSnowflake(unittest.TestCase):
             'key6': None
         }, record)
 
+
+    def test_adjust_timestamps_in_record_unexpected_int_will_raise_exception(self):
+        record = {
+            'key': 100,
+        }
+
+        schema = {
+            'properties': {
+                'key': {'type': ['null', 'string'], 'format': 'date'},
+            }
+        }
+
+        with assert_raises(target_snowflake.UnexpectedValueTypeException):
+            target_snowflake.adjust_timestamps_in_record(record, schema)
+
     def test_write_record_to_uncompressed_file(self):
         records = {'pk_1': 'data1,data2,data3,data4'}
 
@@ -116,7 +132,7 @@ class TestTargetSnowflake(unittest.TestCase):
 
         # Read and validate uncompressed CSV file
         with open(csv_file.name, 'rt') as f:
-            self.assertEquals(f.readlines(), ['data1,data2,data3,data4\n'])
+            self.assertEqual(f.readlines(), ['data1,data2,data3,data4\n'])
 
         os.remove(csv_file.name)
 
@@ -130,6 +146,6 @@ class TestTargetSnowflake(unittest.TestCase):
 
         # Read and validate gzip compressed CSV file
         with gzip.open(csv_file.name, 'rt') as f:
-            self.assertEquals(f.readlines(), ['data1,data2,data3,data4\n'])
+            self.assertEqual(f.readlines(), ['data1,data2,data3,data4\n'])
 
         os.remove(csv_file.name)


### PR DESCRIPTION
## Problem

In some case, target-snowflake receives a record where property has `date-time` or `time` format  but the value is an integer or not string.

This is not a bug in target, but rather the source. More info could be seen if `validate_records` is set to true, as it would raise an exception, otherwise, no validation would happen and something will fail later without further logs.

```
File "/app/.virtualenvs/target-snowflake/lib/python3.7/site-packages/target_snowflake/init.py", line 136, in reset_new_value
parser.parse(record[key])
File "/app/.virtualenvs/target-snowflake/lib/python3.7/site-packages/dateutil/parser/_parser.py", line 1374, in parse
return DEFAULTPARSER.parse(timestr, **kwargs)
File "/app/.virtualenvs/target-snowflake/lib/python3.7/site-packages/dateutil/parser/_parser.py", line 646, in parse
res, skipped_tokens = self._parse(timestr, **kwargs)
File "/app/.virtualenvs/target-snowflake/lib/python3.7/site-packages/dateutil/parser/_parser.py", line 725, in _parse
l = _timelex.split(timestr) # Splits the timestr into tokens
File "/app/.virtualenvs/target-snowflake/lib/python3.7/site-packages/dateutil/parser/_parser.py", line 207, in split
return list(cls(s))
File "/app/.virtualenvs/target-snowflake/lib/python3.7/site-packages/dateutil/parser/_parser.py", line 76, in init
'{itype}'.format(itype=instream.class.name))
TypeError: Parser must be a string or character stream, not int
```

Related issues:
https://github.com/transferwise/pipelinewise/issues/591
https://github.com/transferwise/pipelinewise-target-snowflake/issues/102

## Proposed changes
 
* Add a check for the type of the value before trying to parse it.
* Add logs
* some pylinting

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Improvement
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions