### PR TITLE
[AP-983] Run SHOW FILE FORMATS SQL only once

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -162,7 +162,7 @@ def create_query_tag(query_tag_pattern: str, database: str = None, schema: str =
 class DbSync:
     """DbSync class"""
 
-    def __init__(self, connection_config, stream_schema_message=None, table_cache=None):
+    def __init__(self, connection_config, stream_schema_message=None, table_cache=None, file_format_type=None):
         """
             connection_config:      Snowflake connection details
 
@@ -205,7 +205,7 @@ class DbSync:
 
         self.schema_name = None
         self.grantees = None
-        self.file_format = FileFormat(self.connection_config['file_format'], self.query)
+        self.file_format = FileFormat(self.connection_config['file_format'], self.query, file_format_type)
 
         if not self.connection_config.get('stage') and self.file_format.file_format_type == FileFormatTypes.PARQUET:
             self.logger.error("Table stages with Parquet file format is not suppported. "

--- a/target_snowflake/file_format.py
+++ b/target_snowflake/file_format.py
@@ -24,11 +24,15 @@ class FileFormatTypes(str, Enum):
 class FileFormat:
     """File Format class"""
 
-    def __init__(self, file_format: str, query_fn: Callable):
+    def __init__(self, file_format: str, query_fn: Callable, file_format_type: FileFormatTypes=None):
         """Find the file format in Snowflake, detect its type and
         initialise file format specific functions"""
-        # Detect file format type by querying it from Snowflake
-        self.file_format_type = self._detect_file_format_type(file_format, query_fn)
+        if file_format_type:
+            self.file_format_type = file_format_type
+        else:
+            # Detect file format type by querying it from Snowflake
+            self.file_format_type = self._detect_file_format_type(file_format, query_fn)
+
         self.formatter = self._get_formatter(self.file_format_type)
 
     @classmethod

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -55,8 +55,8 @@ class TestIntegration(unittest.TestCase):
         Selecting from a real table instead of INFORMATION_SCHEMA and keeping it
         in memory while the target-snowflake is running results better load performance.
         """
-        table_cache = target_snowflake.load_table_cache(self.config)
-        target_snowflake.persist_lines(self.config, lines, table_cache)
+        table_cache, file_format_type = target_snowflake.get_snowflake_statics(self.config)
+        target_snowflake.persist_lines(self.config, lines, table_cache, file_format_type)
 
     def remove_metadata_columns_from_rows(self, rows):
         """Removes metadata columns from a list of rows"""
@@ -1072,18 +1072,6 @@ class TestIntegration(unittest.TestCase):
             'QUERIES': 6
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}..TEST_TABLE_ONE',
-            'QUERIES': 2
-            },
-            {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}..TEST_TABLE_THREE',
-            'QUERIES': 2
-            },
-            {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}..TEST_TABLE_TWO',
-            'QUERIES': 2
-            },
-            {
             'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_ONE',
             'QUERIES': 12
             },
@@ -1094,6 +1082,16 @@ class TestIntegration(unittest.TestCase):
             {
             'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_TWO',
             'QUERIES': 10
+            }
+        ])
+
+        # Detecting file format type should run only once
+        result = snowflake.query(f"""SELECT count(*) show_file_format_queries
+                                 FROM table(information_schema.query_history_by_user('{self.config['user']}'))
+                                 WHERE query_tag like '%%PPW test tap run at {current_time}%%'
+                                   AND query_text like 'SHOW FILE FORMATS%%'""")
+        self.assertEqual(result, [{
+            'SHOW_FILE_FORMAT_QUERIES': 1
             }
         ])
 


### PR DESCRIPTION
## Problem

target-snowflake added parquet support. To detect the required file format it's running an SQL command: `SHOW FILE FORMATS`.

At the moment this SQL triggered to run for every selected table but it's enough to run only once. These extra queries add unnecessary overhead on some taps that's required to load lot of tables. For example a tap where more than hundred tables selected, the tap is waiting for 5 minutes to retrieve all the hundred of SQL queries before it starts reading the binlog.

## Proposed changes

The `SHOW FILE FORMATS` command should run only once at the beginning similar to the `SHOW COLUMNS IN SCHEMA` [here](https://github.com/transferwise/pipelinewise-target-snowflake/blob/8b5f756270fd8356bba66afcb49a51d007ff4c71/target_snowflake/db_sync.py#L586)

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions