### PR TITLE
AP1011 - Custom archive bucket/folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ Full list of options in `config.json`:
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary files with RECORD messages. |
 | no_compression                      | Boolean |            | (Default: False) Generate uncompressed files when loading to Snowflake. Normally, by default GZIP compressed files are generated. |
 | query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `{{database}}`, `{{schema}}` and `{{table}}` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
-| archive_load_files                  | Boolean |            | (Default: False) When enabled, the files loaded to Snowflake will also be stored in `{{s3_bucket}}` under the key `/archive/{schema_name}/{table_name}/`. All archived files will have `tap`, `schema`, `table` and `archived-by` as S3 metadata keys. When incremental replication is used, the archived files will also have the following S3 metadata keys: `incremental-key`, `incremental-key-min` and `incremental-key-max`. 
+| archive_load_files                  | Boolean |            | (Default: False) When enabled, the files loaded to Snowflake will also be stored in `archive_load_files_s3_bucket` under the key `/{archive_load_files_s3_prefix}/{schema_name}/{table_name}/`. All archived files will have `tap`, `schema`, `table` and `archived-by` as S3 metadata keys. When incremental replication is used, the archived files will also have the following S3 metadata keys: `incremental-key`, `incremental-key-min` and `incremental-key-max`. 
+| archive_load_files_s3_prefix        | String  |            | (Default: "archive") When `archive_load_files` is enabled, the archived files will be placed in the archive S3 bucket under this prefix.
+| archive_load_files_s3_bucket        | String  |            | (Default: Value of `s3_bucket`) When `archive_load_files` is enabled, the archived files will be placed in this bucket.
 
 ### To run tests:
 

--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -491,9 +491,8 @@ def flush_records(stream: str,
             })
 
         # Use same file name as in import
-        archive_file = s3_key.split('/')[-1]
-        archive_folder = "archive/{}/{}".format(archive_tap, archive_table)
-        archive_key = "{}/{}".format(archive_folder, archive_file)
+        archive_file = os.path.basename(s3_key)
+        archive_key = "{}/{}/{}".format(archive_tap, archive_table, archive_file)
 
         db_sync.copy_to_archive(s3_key, archive_key, archive_metadata)
 

--- a/target_snowflake/upload_clients/base_upload_client.py
+++ b/target_snowflake/upload_clients/base_upload_client.py
@@ -26,7 +26,7 @@ class BaseUploadClient(ABC):
         """
 
     @abstractmethod
-    def copy_object(self, source_key: str, target_key: str, target_metadata: dict) -> None:
+    def copy_object(self, copy_source: str, target_bucket: str, target_key: str, target_metadata: dict) -> None:
         """
         Copy object
         """

--- a/target_snowflake/upload_clients/s3_upload_client.py
+++ b/target_snowflake/upload_clients/s3_upload_client.py
@@ -98,13 +98,9 @@ class S3UploadClient(BaseUploadClient):
         bucket = self.connection_config['s3_bucket']
         self.s3_client.delete_object(Bucket=bucket, Key=key)
 
-    def copy_object(self, source_key: str, target_key: str, target_metadata: dict) -> None:
+    def copy_object(self, copy_source: str, target_bucket: str, target_key: str, target_metadata: dict) -> None:
         """Copy object to another location on S3"""
-        self.logger.info('Copying %s to %s', source_key, target_key)
-        bucket = self.connection_config['s3_bucket']
-
-        copy_source = "{}/{}".format(bucket, source_key)
-
+        self.logger.info('Copying %s to %s/%s', copy_source, target_bucket, target_key)
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.copy_object
-        self.s3_client.copy_object(CopySource=copy_source, Bucket=bucket, Key=target_key, Metadata=target_metadata,
-                                   MetadataDirective="REPLACE")
+        self.s3_client.copy_object(CopySource=copy_source, Bucket=target_bucket, Key=target_key,
+                                   Metadata=target_metadata, MetadataDirective="REPLACE")

--- a/target_snowflake/upload_clients/snowflake_upload_client.py
+++ b/target_snowflake/upload_clients/snowflake_upload_client.py
@@ -39,6 +39,6 @@ class SnowflakeUploadClient(BaseUploadClient):
         with self.dblink.open_connection() as connection:
             connection.cursor().execute(f"REMOVE '@{stage}/{key}'")
 
-    def copy_object(self, source_key: str, target_key: str, target_metadata: dict) -> None:
+    def copy_object(self, copy_source: str, target_bucket: str, target_key: str, target_metadata: dict) -> None:
         raise NotImplementedError(
             "Copying objects is not supported with a Snowflake upload client.")

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1180,6 +1180,7 @@ class TestIntegration(unittest.TestCase):
     def test_archive_load_files(self):
         """Test if load file is copied to archive folder"""
         self.config['archive_load_files'] = True
+        self.config['archive_load_files_s3_prefix'] = 'archive_folder'
         self.config['tap_id'] = 'test_tap_id'
         self.config['client_side_encryption_master_key'] = ''
 
@@ -1187,7 +1188,7 @@ class TestIntegration(unittest.TestCase):
 
         # Delete any dangling files from archive
         files_in_s3_archive = self.s3_client.list_objects(
-            Bucket=s3_bucket, Prefix="archive/test_tap_id/").get('Contents', [])
+            Bucket=s3_bucket, Prefix="archive_folder/test_tap_id/").get('Contents', [])
         for file_in_archive in files_in_s3_archive:
             key = file_in_archive["Key"]
             self.s3_client.delete_object(Bucket=s3_bucket, Key=key)
@@ -1196,7 +1197,7 @@ class TestIntegration(unittest.TestCase):
         self.persist_lines_with_cache(tap_lines)
 
         # Verify expected file metadata in S3
-        files_in_s3_archive = self.s3_client.list_objects(Bucket=s3_bucket, Prefix="archive/test_tap_id/").get(
+        files_in_s3_archive = self.s3_client.list_objects(Bucket=s3_bucket, Prefix="archive_folder/test_tap_id/").get(
             'Contents')
         self.assertIsNotNone(files_in_s3_archive)
         self.assertEqual(1, len(files_in_s3_archive))
@@ -1229,6 +1230,3 @@ class TestIntegration(unittest.TestCase):
 4,"xyz4","not-formatted-time-4"
 5,"xyz5","not-formatted-time-5"
 ''')
-
-        # Clean up
-        self.s3_client.delete_object(Bucket=s3_bucket, Key=archived_file_key)

--- a/tests/unit/test_target_snowflake.py
+++ b/tests/unit/test_target_snowflake.py
@@ -100,13 +100,13 @@ class TestTargetSnowflake(unittest.TestCase):
         instance = dbSync_mock.return_value
         instance.create_schema_if_not_exists.return_value = None
         instance.sync_table.return_value = None
-        instance.put_to_stage.return_value = 'some-s3-bucket/some-s3-folder/some-name_date_batch_hash.csg.gz'
+        instance.put_to_stage.return_value = 'some-s3-folder/some-name_date_batch_hash.csg.gz'
 
         target_snowflake.persist_lines(self.config, lines)
 
         copy_to_archive_args = instance.copy_to_archive.call_args[0]
-        assert copy_to_archive_args[0] == 'some-s3-bucket/some-s3-folder/some-name_date_batch_hash.csg.gz'
-        assert copy_to_archive_args[1] == 'archive/test_tap_id/test_simple_table/some-name_date_batch_hash.csg.gz'
+        assert copy_to_archive_args[0] == 'some-s3-folder/some-name_date_batch_hash.csg.gz'
+        assert copy_to_archive_args[1] == 'test_tap_id/test_simple_table/some-name_date_batch_hash.csg.gz'
         assert copy_to_archive_args[2] == {
             'tap': 'test_tap_id',
             'schema': 'tap_mysql_test',
@@ -122,7 +122,6 @@ class TestTargetSnowflake(unittest.TestCase):
     def test_archive_load_files_log_based_replication(self, os_remove_mock, dbSync_mock):
         self.config['tap_id'] = 'test_tap_id'
         self.config['archive_load_files'] = True
-        self.config['s3_bucket'] = 'dummy_bucket'
 
         with open(f'{os.path.dirname(__file__)}/resources/logical-streams.json', 'r') as f:
             lines = f.readlines()
@@ -130,13 +129,13 @@ class TestTargetSnowflake(unittest.TestCase):
         instance = dbSync_mock.return_value
         instance.create_schema_if_not_exists.return_value = None
         instance.sync_table.return_value = None
-        instance.put_to_stage.return_value = 'some-s3-bucket/some-s3-folder/some-name_date_batch_hash.csg.gz'
+        instance.put_to_stage.return_value = 'some-s3-folder/some-name_date_batch_hash.csg.gz'
 
         target_snowflake.persist_lines(self.config, lines)
 
         copy_to_archive_args = instance.copy_to_archive.call_args[0]
-        assert copy_to_archive_args[0] == 'some-s3-bucket/some-s3-folder/some-name_date_batch_hash.csg.gz'
-        assert copy_to_archive_args[1] == 'archive/test_tap_id/logical1_table2/some-name_date_batch_hash.csg.gz'
+        assert copy_to_archive_args[0] == 'some-s3-folder/some-name_date_batch_hash.csg.gz'
+        assert copy_to_archive_args[1] == 'test_tap_id/logical1_table2/some-name_date_batch_hash.csg.gz'
         assert copy_to_archive_args[2] == {
             'tap': 'test_tap_id',
             'schema': 'logical1',


### PR DESCRIPTION
## Problem

The archive_load_files feature added in https://github.com/transferwise/pipelinewise-target-snowflake/pull/178 only allows archival in the same S3 bucket as is used to the Snowflake imports.

This means that S3 bucket versioning will either be enabled for both archived files and the temporary load files, or neither.

Versioning makes sense for archived files, where accidental deletes could be problematic. It does not, however, make sense for the temporary load files, and having it enabled for them will incur unnecessary cost.

## Proposed changes

This PR allows configuring a separate S3 bucket to be used as the archive destination, as well as customizing the S3 prefix used.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions