### PR TITLE
Do not log record message

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -387,8 +387,9 @@ class DbSync:
             key_props = [str(flatten[p]) for p in self.stream_schema_message['key_properties']]
         except Exception as exc:
             self.logger.error(
-                'Cannot find %s primary key(s) in record: %s', self.stream_schema_message['key_properties'],
-                flatten)
+                'Cannot find %s primary key(s) in record. Available fields: %s',
+                self.stream_schema_message['key_properties'],
+                list(flatten.keys()))
             raise exc
         return ','.join(key_props)
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -11,7 +11,7 @@ import target_snowflake.flattening as flattening
 import target_snowflake.stream_utils as stream_utils
 from target_snowflake.file_format import FileFormat, FileFormatTypes
 
-from target_snowflake.exceptions import TooManyRecordsException
+from target_snowflake.exceptions import TooManyRecordsException, PrimaryKeyNotFoundException
 from target_snowflake.upload_clients.s3_upload_client import S3UploadClient
 from target_snowflake.upload_clients.snowflake_upload_client import SnowflakeUploadClient
 
@@ -386,11 +386,9 @@ class DbSync:
         try:
             key_props = [str(flatten[p]) for p in self.stream_schema_message['key_properties']]
         except Exception as exc:
-            self.logger.error(
-                'Cannot find %s primary key(s) in record. Available fields: %s',
+            raise PrimaryKeyNotFoundException('Cannot find {} primary key(s) in record. Available fields: {}'.format(
                 self.stream_schema_message['key_properties'],
-                list(flatten.keys()))
-            raise exc
+                list(flatten.keys()))) from exc
         return ','.join(key_props)
 
     def put_to_stage(self, file, stream, count, temp_dir=None):

--- a/target_snowflake/exceptions.py
+++ b/target_snowflake/exceptions.py
@@ -27,3 +27,7 @@ class InvalidFileFormatException(Exception):
 
 class UnexpectedMessageTypeException(Exception):
     """Exception to raise when provided message doesn't match the expected type"""
+
+
+class PrimaryKeyNotFoundException(Exception):
+    """Exception to raise when primary key not found in the record message"""

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from target_snowflake import db_sync
 from target_snowflake.file_format import FileFormatTypes
-from target_snowflake.exceptions import InvalidFileFormatException, FileFormatNotFoundException
+from target_snowflake.exceptions import InvalidFileFormatException, FileFormatNotFoundException, PrimaryKeyNotFoundException
 
 
 class TestDBSync(unittest.TestCase):
@@ -305,5 +305,6 @@ class TestDBSync(unittest.TestCase):
         # Missing field as PK
         stream_schema_message['key_properties'] = ['invalid_col']
         dbsync = db_sync.DbSync(minimal_config, stream_schema_message)
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(PrimaryKeyNotFoundException,
+                                    "Cannot find \['invalid_col'\] primary key\(s\) in record\. Available fields: \['id', 'c_str'\]"):
             dbsync.record_primary_key_string({'id': 123, 'c_str': 'xyz'})


### PR DESCRIPTION
## Problem

Some exceptions logging original record messages. We should hide them.

## Proposed changes

Don't dump the original record messages as logs.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions