### PR TITLE
AP-210 increase max_records by an order of magnitude

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -606,7 +606,7 @@ class DbSync:
 
                 # Run everything in one transaction
                 try:
-                    tables = self.query(queries, max_records=9999)
+                    tables = self.query(queries, max_records=99999)
 
                 # Catch exception when schema not exists and SHOW TABLES throws a ProgrammingError
                 # Regexp to extract snowflake error code and message from the exception message


### PR DESCRIPTION
## Problem
This increases the max_records allowed by a Snowflake target when the running the schema columns check `SHOW COLUMNS IN SCHEMA snowflake_db.destination_schema`

This issue is caused by the fact that my source database has many monthly partition tables of same table so we have many versions of the same table, which duplicates the number of columns.

See https://github.com/transferwise/pipelinewise-target-snowflake/issues/210.

## Proposed changes
Increases the maximum number of columns allowed by pipelinewise snowflake target such that we can handle larger databases sizes.


## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions