### PR TITLE
Bump snowflake-connector-python[pandas] from 2.4.6 to 2.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name="pipelinewise-target-snowflake",
       py_modules=["target_snowflake"],
       install_requires=[
           'pipelinewise-singer-python==1.*',
-          'snowflake-connector-python[pandas]==2.4.6',
+          'snowflake-connector-python[pandas]==2.6.2',
           'inflection==0.5.1',
           'joblib==1.1.0',
           'numpy<1.21.0',

--- a/target_snowflake/upload_clients/s3_upload_client.py
+++ b/target_snowflake/upload_clients/s3_upload_client.py
@@ -6,7 +6,7 @@ import boto3
 import datetime
 
 from snowflake.connector.encryption_util import SnowflakeEncryptionUtil
-from snowflake.connector.remote_storage_util import SnowflakeFileEncryptionMaterial
+from snowflake.connector.storage_client import SnowflakeFileEncryptionMaterial
 
 from .base_upload_client import BaseUploadClient
 


### PR DESCRIPTION
## Problem

Snowflake connector is relatively old. This PR is the extended version of #209

## Proposed changes

Bumps snowflake-connector-python from 2.4.6 to 2.6.2 and refactor the code to be compatible with the new version.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Other


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions