### PR TITLE
Handle `anyOf` types other than string, array, object

### DIFF
--- a/target_snowflake/flattening.py
+++ b/target_snowflake/flattening.py
@@ -48,11 +48,13 @@ def flatten_schema(d, parent_key=None, sep='__', level=0, max_level=0):
     for k, v in d['properties'].items():
         new_key = flatten_key(k, parent_key, sep)
         if 'type' in v.keys():
+            # This is probably skipping over values
             if 'object' in v['type'] and 'properties' in v and level < max_level:
                 items.extend(flatten_schema(v, parent_key + [k], sep=sep, level=level + 1, max_level=max_level).items())
             else:
                 items.append((new_key, v))
         else:
+            # handle situations where, e.g., an `anyOf` value is passed
             if len(v.values()) > 0:
                 if list(v.values())[0][0]['type'] == 'string':
                     list(v.values())[0][0]['type'] = ['null', 'string']
@@ -62,6 +64,9 @@ def flatten_schema(d, parent_key=None, sep='__', level=0, max_level=0):
                     items.append((new_key, list(v.values())[0][0]))
                 elif list(v.values())[0][0]['type'] == 'object':
                     list(v.values())[0][0]['type'] = ['null', 'object']
+                    items.append((new_key, list(v.values())[0][0]))
+                else:
+                    list(v.values())[0][0]['type'] = ['null', 'string']
                     items.append((new_key, list(v.values())[0][0]))
 
     key_func = lambda item: item[0]

--- a/target_snowflake/flattening.py
+++ b/target_snowflake/flattening.py
@@ -48,7 +48,6 @@ def flatten_schema(d, parent_key=None, sep='__', level=0, max_level=0):
     for k, v in d['properties'].items():
         new_key = flatten_key(k, parent_key, sep)
         if 'type' in v.keys():
-            # This is probably skipping over values
             if 'object' in v['type'] and 'properties' in v and level < max_level:
                 items.extend(flatten_schema(v, parent_key + [k], sep=sep, level=level + 1, max_level=max_level).items())
             else:

--- a/tests/unit/test_flattening.py
+++ b/tests/unit/test_flattening.py
@@ -61,6 +61,24 @@ class TestFlattening(unittest.TestCase):
             }
         }
 
+        not_nested_schema_with_anyof_property_type = {
+            "type": "object",
+            "properties": {
+                "object_col": {"anyOf": [{"type": "object"}, {"type": ["null", "string"]}]},
+                "array_col": {"anyOf": [{"type": "array"}, {"type": ["null", "string"]}]},
+                "bool_col": {"anyOf": [{"type": ["boolean", "null"]}, {"type": ["null", "string"]}]}
+            }
+        }
+        flattened_schema_with_anyof_property_type = {
+            "object_col": {"type": ["null", "object"]},
+            "array_col": {"type": ["null", "array"]},
+            "bool_col": {"type": ["null", "string"]}
+        }
+
+        # NO FLATTENING - Schema with anyOf properties should be cast to a single data type
+        self.assertEqual(flatten_schema(not_nested_schema_with_anyof_property_type),
+                         flattened_schema_with_anyof_property_type)
+
         # NO FLATTENING - Schema with object type property but without further properties should be a plain dictionary
         # No flattening (default)
         self.assertEqual(flatten_schema(nested_schema_with_properties), nested_schema_with_properties['properties'])


### PR DESCRIPTION
## Problem

I have a situation where a tap emits a schema record of the type:

```
{
   "stream" : "test_stream",
   "type" : "SCHEMA",
   "key_properties" : ["test_col"],
   "schema" : {
      "properties" : {
         "test_col" : {
            "anyOf" : [
               {
                  "multipleOf" : 1e-15,
                  "type" : "number"
               },
               {
                  "type" : [
                     "null",
                     "string"
                  ]
               }
            ]
         }
      },
      "type" : "object"
   }
}
```

As noted in #228, the attribute is skipped over and does not appear in the resulting table.

## Proposed changes

This PR resolves this issue. The root cause was that, during flattening of the schema, logic is present to handle `anyOf` values (and potentially other keys). However, it is only written to handle cases where the first possibility is `object`, `string` or `array`. In my case, this is a `number` value.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions