### PR TITLE
Consider flush_all_streams for schema updates

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -240,13 +240,19 @@ def persist_lines(config, lines, table_cache=None, file_format_type: FileFormatT
                 # if same stream has been encountered again, it means the schema might have been altered
                 # so previous records need to be flushed
                 if row_count.get(stream, 0) > 0:
+                    # flush all streams, delete records if needed, reset counts and then emit current state
+                    if config.get('flush_all_streams'):
+                        filter_streams = None
+                    else:
+                        filter_streams = [stream]
                     flushed_state = flush_streams(records_to_load,
                                                   row_count,
                                                   stream_to_sync,
                                                   config,
                                                   state,
                                                   flushed_state,
-                                                  archive_load_files_data)
+                                                  archive_load_files_data,
+                                                  filter_streams=filter_streams)
 
                     # emit latest encountered state
                     emit_state(flushed_state)


### PR DESCRIPTION
## Problem

Due to a high number of schema messages due to handling TOAST messages in https://github.com/transferwise/pipelinewise-tap-postgres/issues/146 all the records are constantly flushed resulting in very slow performance.

## Proposed changes

This changes ensures the `flush_all_streams` configuration setting is honored when a new schema message arrives in the target. If this is not set, then only the records for the current stream are flushed instead for all rows.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions