### PR TITLE
AP-1110 Handle change to key properties and remove non-nullability constraint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ pylint:
 
 unit_test:
 	. ./venv/bin/activate ;\
-	pytest tests/unit -vv --cov target_snowflake --cov-fail-under=62
+	pytest tests/unit -vv --cov target_snowflake --cov-fail-under=67
 
 integration_test:
 	. ./venv/bin/activate ;\

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -380,7 +380,7 @@ class DbSync:
         for key_prop in self.stream_schema_message['key_properties']:
             if not flatten.get(key_prop):
                 raise PrimaryKeyNotFoundException(
-                    f"Primary key '{key_prop}' is nonexistent or null in record."
+                    f"Primary key '{key_prop}' does not exist in record or is null. "
                     f"Available fields: {list(flatten.keys())}")
 
             key_props.append(str(flatten[key_prop]))

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -115,9 +115,11 @@ def safe_column_name(name):
     """Generate SQL friendly column name"""
     return f'"{name}"'.upper()
 
+
 def json_element_name(name):
     """Generate SQL friendly semi structured element reference name"""
     return f'"{name}"'
+
 
 def column_clause(name, schema_property):
     """Generate DDL column name with column type string"""
@@ -214,7 +216,7 @@ class DbSync:
         self.file_format = FileFormat(self.connection_config['file_format'], self.query, file_format_type)
 
         if not self.connection_config.get('stage') and self.file_format.file_format_type == FileFormatTypes.PARQUET:
-            self.logger.error("Table stages with Parquet file format is not suppported. "
+            self.logger.error("Table stages with Parquet file format is not supported. "
                               "Use named stages with Parquet file format or table stages with CSV files format")
             sys.exit(1)
 
@@ -323,7 +325,7 @@ class DbSync:
 
                 # Run every query in one transaction if query is a list of SQL
                 if isinstance(query, list):
-                    self.logger.info('Starting Transaction')
+                    self.logger.debug('Starting Transaction')
                     cur.execute("START TRANSACTION")
                     queries = query
                 else:
@@ -337,7 +339,7 @@ class DbSync:
                     # update the LAST_QID
                     params['LAST_QID'] = qid
 
-                    self.logger.info("Running query: '%s' with Params %s", q, params)
+                    self.logger.debug("Running query: '%s' with Params %s", q, params)
 
                     cur.execute(q, params)
                     qid = cur.sfqid
@@ -392,7 +394,6 @@ class DbSync:
 
     def delete_from_stage(self, stream, s3_key):
         """Delete file from snowflake stage"""
-        self.logger.info('Deleting %s from stage', format(s3_key))
         self.upload_client.delete_object(stream, s3_key)
 
     def copy_to_archive(self, s3_source_key, s3_archive_key, s3_archive_metadata):
@@ -533,6 +534,7 @@ class DbSync:
                 if len(results) > 0:
                     inserts = results[0].get('rows_loaded', 0)
         return inserts
+
     def primary_key_merge_condition(self):
         """Generate SQL join condition on primary keys for merge SQL statements"""
         stream_schema_message = self.stream_schema_message
@@ -809,7 +811,6 @@ class DbSync:
             query = self.create_table_query()
             self.logger.info('Table %s does not exist. Creating...', table_name_with_schema)
             self.query(query)
-
             self.grant_privilege(self.schema_name, self.grantees, self.grant_select_on_all_tables_in_schema)
 
             # Refresh columns cache if required

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -851,6 +851,10 @@ class DbSync:
                 f'alter table {table_name} add primary key({pk_list});'
             ])
 
+        # For now, we don't wish to enforce non-nullability on the pk columns
+        for pk in current_pks.union(new_pks):
+            queries.append(f'alter table {table_name} alter column {safe_column_name(pk)} drop not null;')
+
         self.query(queries)
 
     def _get_current_pks(self) -> Set[str]:

--- a/tests/integration/resources/messages-with-changing-pk.json
+++ b/tests/integration/resources/messages-with-changing-pk.json
@@ -1,0 +1,13 @@
+{"type": "SCHEMA", "stream": "tap_mysql_test-test_simple_table", "schema": {"properties": {"id": {"type": ["integer"]}, "results": {"type": ["null", "string"]}, "time_created": {"type": ["null", "string"]}}, "type": "date-time"}, "key_properties": ["id"]}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 1, "version": 1}}}}
+{"type": "ACTIVATE_VERSION", "stream": "tap_mysql_test-test_simple_table", "version": 1}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 1, "results": "xyz1", "time_created": "2019-12-01T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 2, "results": "xyz2", "time_created": "2019-12-03T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 2, "version": 1}}}}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 3, "results": "xyz3", "time_created": "2019-12-09T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 4, "results": "xyz4", "time_created": "2019-12-11T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 4, "version": 1}}}}
+{"type": "SCHEMA", "stream": "tap_mysql_test-test_simple_table", "schema": {"properties": {"id": {"type": ["integer"]}, "name": {"type":  "string"}, "results": {"type": ["null", "string"]}, "time_created": {"type": ["null", "string"]}}, "type": "date-time"}, "key_properties": ["id", "name"]}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 5, "name": "A", "results": "xyz5", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 6, "name": "B", "results": "xyz6", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 6, "version": 1}}}}

--- a/tests/integration/resources/messages-with-null-pk.json
+++ b/tests/integration/resources/messages-with-null-pk.json
@@ -1,0 +1,8 @@
+{"type": "SCHEMA", "stream": "tap_mysql_test-test_simple_table", "schema": {"properties": {"id": {"type": ["integer"]}, "results": {"type": ["null", "string"]}, "time_created": {"type": ["null", "string"]}}, "type": "date-time"}, "key_properties": ["id"]}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 1, "version": 1}}}}
+{"type": "ACTIVATE_VERSION", "stream": "tap_mysql_test-test_simple_table", "version": 1}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 1, "results": "xyz1", "time_created": "2019-12-01T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 2, "results": "xyz2", "time_created": "2019-12-03T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 2, "version": 1}}}}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": null, "results": "xyz3", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": null, "results": "xyz4", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1170,15 +1170,15 @@ class TestIntegration(unittest.TestCase):
         },
             {
                 'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_ONE',
-                'QUERIES': 7
+                'QUERIES': 10
             },
             {
                 'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_THREE',
-                'QUERIES': 6
+                'QUERIES': 9
             },
             {
                 'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_TWO',
-                'QUERIES': 6
+                'QUERIES': 9
             }
         ])
 

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -8,8 +8,8 @@ import botocore
 import boto3
 import target_snowflake
 
-
 from target_snowflake import RecordValidationException
+from target_snowflake.exceptions import PrimaryKeyNotFoundException
 from target_snowflake.db_sync import DbSync
 from target_snowflake.upload_clients.s3_upload_client import S3UploadClient
 
@@ -38,11 +38,15 @@ class TestIntegration(unittest.TestCase):
 
     def setUp(self):
         self.config = test_utils.get_test_config()
-        snowflake = DbSync(self.config)
+        self.snowflake = DbSync(self.config)
 
         # Drop target schema
         if self.config['default_target_schema']:
-            snowflake.query("DROP SCHEMA IF EXISTS {}".format(self.config['default_target_schema']))
+            self.snowflake.query("DROP SCHEMA IF EXISTS {}".format(self.config['default_target_schema']))
+
+        if self.config['schema_mapping']:
+            for _, val in self.config['schema_mapping'].items():
+                self.snowflake.query('drop schema if exists {}'.format(val['target_schema']))
 
         # Set up S3 client
         aws_access_key_id = self.config.get('aws_access_key_id')
@@ -760,58 +764,88 @@ class TestIntegration(unittest.TestCase):
             [
                 # Flush #1 - Flushed edgydata until lsn: 108197216
                 mock.call({"currently_syncing": None, "bookmarks": {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723618, "xmin": None},
-                     "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723635, "xmin": None},
-                     "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723651, "xmin": None},
-                     "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
-                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
-                     "public2-wearehere": {}}}),
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
+                    "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
+                    "public2-wearehere": {}}}),
                 # Flush #2 - Flushed logical1-logical1_table2 until lsn: 108201336
                 mock.call({"currently_syncing": None, "bookmarks": {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723618, "xmin": None},
-                     "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108201336, "version": 1570922723635, "xmin": None},
-                     "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723651, "xmin": None},
-                     "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
-                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
-                     "public2-wearehere": {}}}),
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108201336,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
+                    "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
+                    "public2-wearehere": {}}}),
                 # Flush #3 - Flushed logical1-logical1_table2 until lsn: 108237600
                 mock.call({"currently_syncing": None, "bookmarks": {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723618, "xmin": None},
-                     "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108237600, "version": 1570922723635, "xmin": None},
-                     "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723651, "xmin": None},
-                     "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
-                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
-                     "public2-wearehere": {}}}),
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108237600,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
+                    "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
+                    "public2-wearehere": {}}}),
                 # Flush #4 - Flushed logical1-logical1_table2 until lsn: 108238768
                 mock.call({"currently_syncing": None, "bookmarks": {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723618, "xmin": None},
-                     "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108238768, "version": 1570922723635, "xmin": None},
-                     "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723651, "xmin": None},
-                     "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
-                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
-                     "public2-wearehere": {}}}),
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108238768,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
+                    "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
+                    "public2-wearehere": {}}}),
                 # Flush #5 - Flushed logical1-logical1_table2 until lsn: 108239704,
                 mock.call({"currently_syncing": None, "bookmarks": {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723618, "xmin": None},
-                     "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108239896, "version": 1570922723635, "xmin": None},
-                     "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176, "version": 1570922723651, "xmin": None},
-                     "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
-                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
-                     "public2-wearehere": {}}}),
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108239896,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108196176,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
+                    "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
+                    "public2-wearehere": {}}}),
                 # Flush #6 - Last flush, update every stream lsn: 108240872,
                 mock.call({"currently_syncing": None, "bookmarks": {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108240872, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108240872, "version": 1570922723618, "xmin": None},
-                     "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108240872, "version": 1570922723635, "xmin": None},
-                     "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108240872, "version": 1570922723651, "xmin": None},
-                     "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
-                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
-                     "public2-wearehere": {}}}),
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108240872,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108240872,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108240872,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108240872,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
+                    "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
+                    "public2-wearehere": {}}}),
             ])
 
         # Every table should be loaded correctly
@@ -835,56 +869,86 @@ class TestIntegration(unittest.TestCase):
             [
                 # Flush #1 - Flush every stream until lsn: 108197216
                 mock.call({"currently_syncing": None, "bookmarks": {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723618, "xmin": None},
-                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723635, "xmin": None},
-                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108197216, "version": 1570922723651, "xmin": None},
-                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108197216,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
                     "public2-wearehere": {}}}),
                 # Flush #2 - Flush every stream until lsn 108201336
                 mock.call({'currently_syncing': None, 'bookmarks': {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108201336, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108201336, "version": 1570922723618, "xmin": None},
-                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108201336, "version": 1570922723635, "xmin": None},
-                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108201336, "version": 1570922723651, "xmin": None},
-                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108201336,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108201336,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108201336,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108201336,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
                     "public2-wearehere": {}}}),
                 # Flush #3 - Flush every stream until lsn: 108237600
                 mock.call({'currently_syncing': None, 'bookmarks': {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108237600, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108237600, "version": 1570922723618, "xmin": None},
-                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108237600, "version": 1570922723635, "xmin": None},
-                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108237600, "version": 1570922723651, "xmin": None},
-                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108237600,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108237600,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108237600,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108237600,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
                     "public2-wearehere": {}}}),
                 # Flush #4 - Flush every stream until lsn: 108238768
                 mock.call({'currently_syncing': None, 'bookmarks': {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108238768, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108238768, "version": 1570922723618, "xmin": None},
-                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108238768, "version": 1570922723635, "xmin": None},
-                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108238768, "version": 1570922723651, "xmin": None},
-                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108238768,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108238768,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108238768,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108238768,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
                     "public2-wearehere": {}}}),
                 # Flush #5 - Flush every stream until lsn: 108239704,
                 mock.call({'currently_syncing': None, 'bookmarks': {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108239896, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108239896, "version": 1570922723618, "xmin": None},
-                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108239896, "version": 1570922723635, "xmin": None},
-                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108239896, "version": 1570922723651, "xmin": None},
-                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108239896,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108239896,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108239896,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108239896,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
                     "public2-wearehere": {}}}),
                 # Flush #6 - Last flush, update every stream until lsn: 108240872,
                 mock.call({'currently_syncing': None, 'bookmarks': {
-                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108240872, "version": 1570922723596, "xmin": None},
-                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108240872, "version": 1570922723618, "xmin": None},
-                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108240872, "version": 1570922723635, "xmin": None},
-                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108240872, "version": 1570922723651, "xmin": None},
-                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id", "version": 1570922723667, "replication_key_value": 4079},
+                    "logical1-logical1_edgydata": {"last_replication_method": "LOG_BASED", "lsn": 108240872,
+                                                   "version": 1570922723596, "xmin": None},
+                    "logical1-logical1_table1": {"last_replication_method": "LOG_BASED", "lsn": 108240872,
+                                                 "version": 1570922723618, "xmin": None},
+                    "logical1-logical1_table2": {"last_replication_method": "LOG_BASED", "lsn": 108240872,
+                                                 "version": 1570922723635, "xmin": None},
+                    "logical2-logical2_table1": {"last_replication_method": "LOG_BASED", "lsn": 108240872,
+                                                 "version": 1570922723651, "xmin": None},
+                    "public-city": {"last_replication_method": "INCREMENTAL", "replication_key": "id",
+                                    "version": 1570922723667, "replication_key_value": 4079},
                     "public-country": {"last_replication_method": "FULL_TABLE", "version": 1570922730456, "xmin": None},
                     "public2-wearehere": {}}}),
             ])
@@ -1103,18 +1167,18 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(result, [{
             'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}..',
             'QUERIES': 4
+        },
+            {
+                'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_ONE',
+                'QUERIES': 7
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_ONE',
-            'QUERIES': 7
+                'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_THREE',
+                'QUERIES': 6
             },
             {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_THREE',
-            'QUERIES': 6
-            },
-            {
-            'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_TWO',
-            'QUERIES': 6
+                'QUERY_TAG': f'PPW test tap run at {current_time}. Loading into {target_db}.{target_schema}.TEST_TABLE_TWO',
+                'QUERIES': 6
             }
         ])
 
@@ -1125,7 +1189,7 @@ class TestIntegration(unittest.TestCase):
                                    AND query_text like 'SHOW FILE FORMATS%%'""")
         self.assertEqual(result, [{
             'SHOW_FILE_FORMAT_QUERIES': 1
-            }
+        }
         ])
 
     def test_table_stage(self):
@@ -1230,3 +1294,40 @@ class TestIntegration(unittest.TestCase):
 4,"xyz4","not-formatted-time-4"
 5,"xyz5","not-formatted-time-5"
 ''')
+
+    def test_stream_with_changing_pks_should_succeed(self):
+        """Test if table will have its PKs adjusted according to changes in schema key-properties"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-changing-pk.json')
+
+        self.persist_lines_with_cache(tap_lines)
+
+        table_desc = self.snowflake.query(f'desc table {self.config["default_target_schema"]}.test_simple_table;')
+        rows_count = self.snowflake.query(f'select count(1) as _count from'
+                                          f' {self.config["default_target_schema"]}.test_simple_table;')
+
+        self.assertEqual(6, rows_count[0]['_COUNT'])
+
+        self.assertEqual(4, len(table_desc))
+
+        self.assertEqual('ID', table_desc[0]['name'])
+        self.assertEqual('Y', table_desc[0]['null?'])
+        self.assertEqual('Y', table_desc[0]['primary key'])
+
+        self.assertEqual('RESULTS', table_desc[1]['name'])
+        self.assertEqual('Y', table_desc[1]['null?'])
+        self.assertEqual('N', table_desc[1]['primary key'])
+
+        self.assertEqual('TIME_CREATED', table_desc[2]['name'])
+        self.assertEqual('Y', table_desc[2]['null?'])
+        self.assertEqual('N', table_desc[2]['primary key'])
+
+        self.assertEqual('NAME', table_desc[3]['name'])
+        self.assertEqual('Y', table_desc[3]['null?'])
+        self.assertEqual('Y', table_desc[3]['primary key'])
+
+    def test_stream_with_null_values_in_pks_should_fail(self):
+        """Test if null values in PK column should abort the process"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-null-pk.json')
+
+        with self.assertRaises(PrimaryKeyNotFoundException):
+            self.persist_lines_with_cache(tap_lines)

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -271,12 +271,6 @@ class TestDBSync(unittest.TestCase):
         self.assertEqual(db_sync.safe_column_name("column-name"), '"COLUMN-NAME"')
         self.assertEqual(db_sync.safe_column_name("column name"), '"COLUMN NAME"')
 
-    def json_element_name(self):
-        self.assertEqual(db_sync.safe_column_name("columnname"), 'columnname"')
-        self.assertEqual(db_sync.safe_column_name("columnName"), 'columnName"')
-        self.assertEqual(db_sync.safe_column_name("column-name"), 'column-name')
-        self.assertEqual(db_sync.safe_column_name('"column name"'), '"column name"')
-
     @patch('target_snowflake.db_sync.DbSync.query')
     def test_record_primary_key_string(self, query_patch):
         query_patch.return_value = [{'type': 'CSV'}]

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -1,6 +1,7 @@
 import json
 import unittest
-from unittest.mock import patch
+
+from unittest.mock import patch, call
 
 from target_snowflake import db_sync
 from target_snowflake.exceptions import PrimaryKeyNotFoundException
@@ -20,7 +21,7 @@ class TestDBSync(unittest.TestCase):
             'dt': {"type": ["string"], "format": "date-time"},
             'dt_or_null': {"type": ["string", "null"], "format": "date-time"},
             'd': {"type": ["string"], "format": "date"},
-            'd_or_null': {"type": ["string", "null"], "format": "date"},            
+            'd_or_null': {"type": ["string", "null"], "format": "date"},
             'time': {"type": ["string"], "format": "time"},
             'time_or_null': {"type": ["string", "null"], "format": "time"},
             'binary': {"type": ["string", "null"], "format": "binary"},
@@ -102,7 +103,7 @@ class TestDBSync(unittest.TestCase):
             'dt': 'timestamp_ntz',
             'dt_or_null': 'timestamp_ntz',
             'd': 'date',
-            'd_or_null': 'date',            
+            'd_or_null': 'date',
             'time': 'time',
             'time_or_null': 'time',
             'binary': 'binary',
@@ -129,7 +130,7 @@ class TestDBSync(unittest.TestCase):
             'dt': '',
             'dt_or_null': '',
             'd': '',
-            'd_or_null': '',            
+            'd_or_null': '',
             'time': '',
             'time_or_null': '',
             'binary': 'to_binary',
@@ -304,8 +305,17 @@ class TestDBSync(unittest.TestCase):
         stream_schema_message['key_properties'] = ['invalid_col']
         dbsync = db_sync.DbSync(minimal_config, stream_schema_message)
         with self.assertRaisesRegex(PrimaryKeyNotFoundException,
-                                    r"Cannot find \['invalid_col'\] primary key\(s\) in record\. Available fields: \['id', 'c_str'\]"):
+                                    r"Primary key 'invalid_col' does not exist in record or is null\. Available "
+                                    r"fields: \['id', 'c_str'\]"):
             dbsync.record_primary_key_string({'id': 123, 'c_str': 'xyz'})
+
+        # Null PK field
+        stream_schema_message['key_properties'] = ['id']
+        dbsync = db_sync.DbSync(minimal_config, stream_schema_message)
+        with self.assertRaisesRegex(PrimaryKeyNotFoundException,
+                                    r"Primary key 'id' does not exist in record or is null\. Available "
+                                    r"fields: \['id', 'c_str'\]"):
+            dbsync.record_primary_key_string({'id': None, 'c_str': 'xyz'})
 
     @patch('target_snowflake.db_sync.DbSync.query')
     @patch('target_snowflake.db_sync.DbSync._load_file_merge')
@@ -382,3 +392,171 @@ class TestDBSync(unittest.TestCase):
         with self.assertRaises(Exception), self.assertLogs(logger=LOGGER_NAME, level="ERROR") as captured_logs:
             dbsync.load_file(s3_key="dummy-key", count=256, size_bytes=256)
         self.assertIn(expected_msg, captured_logs.output)
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_with_no_changes_to_pk(self, query_patch):
+        minimal_config = {
+            'account': "dummy-account",
+            'dbname': "dummy-db",
+            'user': "dummy-user",
+            'password': "dummy-passwd",
+            'warehouse': "dummy-wh",
+            'default_target_schema': "dummy-schema",
+            'file_format': "dummy-file-format"
+        }
+
+        stream_schema_message = {"stream": "public-table1",
+                                 "schema": {
+                                     "properties": {
+                                         "id": {"type": ["integer"]},
+                                         "c_str": {"type": ["null", "string"]}}},
+                                 "key_properties": ["id"]}
+
+        table_cache = [
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER'
+            },
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'C_STR',
+                'DATA_TYPE': 'TEXT'
+            }
+        ]
+        query_patch.side_effect = [
+            [{'type': 'CSV'}],
+            [{'column_name': 'ID'}],
+            None
+        ]
+
+        dbsync = db_sync.DbSync(minimal_config, stream_schema_message, table_cache)
+        dbsync.sync_table()
+
+        query_patch.assert_has_calls([
+            call('SHOW FILE FORMATS LIKE \'dummy-file-format\''),
+            call('show primary keys in table dummy-db.dummy-schema."TABLE1";'),
+            call(['alter table dummy-schema."TABLE1" alter column "ID" drop not null;'])
+        ])
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_with_new_pk_in_stream(self, query_patch):
+        minimal_config = {
+            'account': "dummy-account",
+            'dbname': "dummy-db",
+            'user': "dummy-user",
+            'password': "dummy-passwd",
+            'warehouse': "dummy-wh",
+            'default_target_schema': "dummy-schema",
+            'file_format': "dummy-file-format"
+        }
+
+        stream_schema_message = {"stream": "public-table1",
+                                 "schema": {
+                                     "properties": {
+                                         "id": {"type": ["integer"]},
+                                         "c_str": {"type": ["null", "string"]},
+                                         "name": {"type": ["string"]},
+                                     }
+                                 },
+                                 "key_properties": ["id", "name"]}
+
+        table_cache = [
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER'
+            },
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'C_STR',
+                'DATA_TYPE': 'TEXT'
+            },
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'NAME',
+                'DATA_TYPE': 'TEXT'
+            }
+        ]
+        query_patch.side_effect = [
+            [{'type': 'CSV'}],
+            [{'column_name': 'ID'}],
+            None
+        ]
+
+        dbsync = db_sync.DbSync(minimal_config, stream_schema_message, table_cache)
+        dbsync.sync_table()
+
+        # due to usage of sets in the code, order of columns in queries in not guaranteed
+        # so have to break assertions to account for this.
+        calls = query_patch.call_args_list
+        self.assertEqual(3, len(calls))
+
+        self.assertEqual('SHOW FILE FORMATS LIKE \'dummy-file-format\'', calls[0][0][0])
+        self.assertEqual('show primary keys in table dummy-db.dummy-schema."TABLE1";', calls[1][0][0])
+
+        self.assertEqual('alter table dummy-schema."TABLE1" drop primary key;', calls[2][0][0][0])
+
+        self.assertIn(calls[2][0][0][1], {'alter table dummy-schema."TABLE1" add primary key("ID", "NAME");',
+                                       'alter table dummy-schema."TABLE1" add primary key("NAME", "ID");'})
+
+        self.assertListEqual(sorted(calls[2][0][0][2:]),
+                             [
+                                 'alter table dummy-schema."TABLE1" alter column "ID" drop not null;',
+                                 'alter table dummy-schema."TABLE1" alter column "NAME" drop not null;',
+                             ]
+                             )
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_with_stream_that_changes_to_have_no_pk(self, query_patch):
+        minimal_config = {
+            'account': "dummy-account",
+            'dbname': "dummy-db",
+            'user': "dummy-user",
+            'password': "dummy-passwd",
+            'warehouse': "dummy-wh",
+            'default_target_schema': "dummy-schema",
+            'file_format': "dummy-file-format"
+        }
+
+        stream_schema_message = {"stream": "public-table1",
+                                 "schema": {
+                                     "properties": {
+                                         "id": {"type": ["integer"]},
+                                         "c_str": {"type": ["null", "string"]}}},
+                                 "key_properties": []}
+
+        table_cache = [
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER'
+            },
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'C_STR',
+                'DATA_TYPE': 'TEXT'
+            }
+        ]
+        query_patch.side_effect = [
+            [{'type': 'CSV'}],
+            [{'column_name': 'ID'}],
+            None
+        ]
+
+        dbsync = db_sync.DbSync(minimal_config, stream_schema_message, table_cache)
+        dbsync.sync_table()
+
+        query_patch.assert_has_calls([
+            call('SHOW FILE FORMATS LIKE \'dummy-file-format\''),
+            call('show primary keys in table dummy-db.dummy-schema."TABLE1";'),
+            call(['alter table dummy-schema."TABLE1" drop primary key;',
+                  'alter table dummy-schema."TABLE1" alter column "ID" drop not null;'])
+        ])


### PR DESCRIPTION
## Problem

1. When the source/tap changes the key-properties of a stream, this doesn't reflect in the snowflake table, PKs remain the same and don't change accordingly.
2. SF enforces non-nullability on columns marked as PK. We don't want such behavior.
3. target accepts records that have null values in the fields in key-properties, ie accepts records where PKs are null, then it treats all these records as the same record and updates it in memory to only keep the latest one, this can cause data quality issue.

## Proposed changes

1. Monitor changes to `key-properties` in SCHEMA messages:
    * if it becomes empty, then drop any existing PK from the table
    * if there are new columns or columns are no longer key properties, refresh the table PK constraint to reflect the new PK.
 
2. Drop `non null` constraint on columns that are PK.
3. Raise exception if a record that has null pk field similarly to how it's done when such field doesn't exist in record, because doesn't exist and null value should be treated the same. 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions