### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+2.0.0 (2022-03-29)
+-------------------
+
+*Fixes*
+- Respecting `flush_all_streams` when SCHEMA messages arrive.
+- Improve logging for failed merge & copy queries.
+- Drop NOT NULL constraint from primary key columns.
+- Update PK constraints according to changes to SCHEMA's key properties.
+
+*Changes*
+- Dropping Python 3.6 from CI matrix
+- Adding Python 3.9 to CI matrix
+- Bumpy pytest to `7.1.1`
+
 1.15.0 (2022-01-14)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 - Update PK constraints according to changes to SCHEMA's key properties.
 
 *Changes*
-- Dropping Python 3.6 from CI matrix
-- Adding Python 3.9 to CI matrix
-- Bumpy pytest to `7.1.1`
+- Dropping support for Python 3.6
+- Adding support for Python 3.9
+- Bump pytest to `7.1.1`
+- Bump boto3 to `1.21`
+
 
 1.15.0 (2022-01-14)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name="pipelinewise-target-snowflake",
-      version="1.15.0",
+      version="2.0.0",
       description="Singer.io target for loading data to Snowflake - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name="pipelinewise-target-snowflake",
           'Programming Language :: Python :: 3.9',
       ],
       py_modules=["target_snowflake"],
+      python_requires='>=3.7',
       install_requires=[
           'pipelinewise-singer-python==1.*',
           'snowflake-connector-python[pandas]==2.7.*',


### PR DESCRIPTION
Prep to release the following changes:
 
*Fixes*
- Respecting `flush_all_streams` when SCHEMA messages arrive.
- Improve logging for failed merge & copy queries.
- Drop NOT NULL constraint from primary key columns.
- Update PK constraints according to changes to SCHEMA's key properties.

*Changes*
- Dropping Python 3.6 from CI matrix
- Adding Python 3.9 to CI matrix
- Bump pytest to `7.1.1`
- Bump boto3 to `1.21`