### PR TITLE
AP-1205 AP-1206 Fix issues with primary keys

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -847,10 +847,11 @@ class DbSync:
         elif new_pks != current_pks:
             self.logger.info('Changes detected in pk columns of table "%s", need to refresh PK.', table_name)
             pk_list = ', '.join([safe_column_name(col) for col in new_pks])
-            queries.extend([
-                f'alter table {table_name} drop primary key;',
-                f'alter table {table_name} add primary key({pk_list});'
-            ])
+
+            if current_pks:
+                queries.append(f'alter table {table_name} drop primary key;')
+
+            queries.append(f'alter table {table_name} add primary key({pk_list});')
 
         # For now, we don't wish to enforce non-nullability on the pk columns
         for pk in current_pks.union(new_pks):

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -378,10 +378,11 @@ class DbSync:
 
         key_props = []
         for key_prop in self.stream_schema_message['key_properties']:
-            if not flatten.get(key_prop):
+            if key_prop not in flatten or flatten[key_prop] is None:
                 raise PrimaryKeyNotFoundException(
                     f"Primary key '{key_prop}' does not exist in record or is null. "
-                    f"Available fields: {list(flatten.keys())}")
+                    f"Available fields: {list(flatten.keys())}"
+                )
 
             key_props.append(str(flatten[key_prop]))
 

--- a/tests/integration/resources/messages-with-falsy-pk-values.json
+++ b/tests/integration/resources/messages-with-falsy-pk-values.json
@@ -1,0 +1,13 @@
+{"type": "SCHEMA", "stream": "tap_mysql_test-test_simple_table", "schema": {"properties": {"id": {"type": ["integer"]}, "results": {"type": ["null", "string"]}, "time_created": {"type": ["null", "string"]}}, "type": "date-time"}, "key_properties": ["id"]}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 1, "version": 1}}}}
+{"type": "ACTIVATE_VERSION", "stream": "tap_mysql_test-test_simple_table", "version": 1}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 0, "results": "xyz1", "time_created": "2019-12-01T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 1, "results": "xyz1", "time_created": "2019-12-01T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 2, "results": "xyz2", "time_created": "2019-12-03T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "SCHEMA", "stream": "tap_mysql_test-test_simple_table", "schema": {"properties": {"id": {"type": ["integer"]},  "c_bool": {"type": ["boolean"]}, "results": {"type": ["null", "string"]}, "time_created": {"type": ["null", "string"]}}, "type": "date-time"}, "key_properties": ["id", "c_bool"]}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 2, "version": 1}}}}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 3, "c_bool": false, "results": "xyz3", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 4, "c_bool": true, "results": "xyz4", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 0, "c_bool": true, "results": "xyz4", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 5, "c_bool": false, "results": "xyz4", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 0, "c_bool": false, "results": "xyz4", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}

--- a/tests/integration/resources/messages-with-new-pk.json
+++ b/tests/integration/resources/messages-with-new-pk.json
@@ -1,0 +1,13 @@
+{"type": "SCHEMA", "stream": "tap_mysql_test-test_simple_table", "schema": {"properties": {"id": {"type": ["integer"]}, "results": {"type": ["null", "string"]}, "time_created": {"type": ["null", "string"]}}, "type": "date-time"}, "key_properties": []}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 1, "version": 1}}}}
+{"type": "ACTIVATE_VERSION", "stream": "tap_mysql_test-test_simple_table", "version": 1}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 1, "results": "xyz1", "time_created": "2019-12-01T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 2, "results": "xyz2", "time_created": "2019-12-03T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 2, "version": 1}}}}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 3, "results": "xyz3", "time_created": "2019-12-09T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 4, "results": "xyz4", "time_created": "2019-12-11T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 4, "version": 1}}}}
+{"type": "SCHEMA", "stream": "tap_mysql_test-test_simple_table", "schema": {"properties": {"id": {"type": ["integer"]}, "name": {"type":  "string"}, "results": {"type": ["null", "string"]}, "time_created": {"type": ["null", "string"]}}, "type": "date-time"}, "key_properties": ["id", "name"]}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 5, "name": "A", "results": "xyz5", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_simple_table", "record": {"id": 6, "name": "B", "results": "xyz6", "time_created": "2019-12-17T19:12:12.006049Z"}, "version": 1, "time_extracted": "2019-12-17T19:12:12.006049Z"}
+{"type": "STATE", "value": {"bookmarks": {"tap_mysql_test-test_simple_table": {"replication_key": "id", "replication_key_value": 6, "version": 1}}}}

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -1363,3 +1363,14 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual('NAME', table_desc[3]['name'])
         self.assertEqual('Y', table_desc[3]['null?'])
         self.assertEqual('Y', table_desc[3]['primary key'])
+
+    def test_stream_with_falsy_pks_should_succeed(self):
+        """Test if data will be loaded if records have falsy values"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-falsy-pk-values.json')
+
+        self.persist_lines_with_cache(tap_lines)
+
+        rows_count = self.snowflake.query(f'select count(1) as _count from'
+                                          f' {self.config["default_target_schema"]}.test_simple_table;')
+
+        self.assertEqual(8, rows_count[0]['_COUNT'])

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -290,7 +290,9 @@ class TestDBSync(unittest.TestCase):
                                  "schema": {
                                      "properties": {
                                          "id": {"type": ["integer"]},
-                                         "c_str": {"type": ["null", "string"]}}},
+                                         "c_str": {"type": ["null", "string"]},
+                                         "c_bool": {"type": ["boolean"]}
+                                     }},
                                  "key_properties": ["id"]}
 
         # Single primary key string
@@ -317,6 +319,16 @@ class TestDBSync(unittest.TestCase):
                                     r"Primary key 'id' does not exist in record or is null\. Available "
                                     r"fields: \['id', 'c_str'\]"):
             dbsync.record_primary_key_string({'id': None, 'c_str': 'xyz'})
+
+        # falsy PK field accepted
+        stream_schema_message['key_properties'] = ['id']
+        dbsync = db_sync.DbSync(minimal_config, stream_schema_message)
+        self.assertEqual(dbsync.record_primary_key_string({'id': 0, 'c_str': 'xyz'}), '0')
+
+        # falsy PK field accepted
+        stream_schema_message['key_properties'] = ['id', 'c_bool']
+        dbsync = db_sync.DbSync(minimal_config, stream_schema_message)
+        self.assertEqual(dbsync.record_primary_key_string({'id': 1, 'c_bool': False, 'c_str': 'xyz'}), '1,False')
 
     @patch('target_snowflake.db_sync.DbSync.query')
     @patch('target_snowflake.db_sync.DbSync._load_file_merge')

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -150,13 +150,14 @@ class TestDBSync(unittest.TestCase):
         self.assertIsNone(db_sync.create_query_tag(None))
         self.assertEqual(db_sync.create_query_tag('This is a test query tag'), 'This is a test query tag')
         self.assertEqual(db_sync.create_query_tag('Loading into {{database}}.{{schema}}.{{table}}',
-                                        database='test_database',
-                                        schema='test_schema',
-                                        table='test_table'), 'Loading into test_database.test_schema.test_table')
+                                                  database='test_database',
+                                                  schema='test_schema',
+                                                  table='test_table'),
+                         'Loading into test_database.test_schema.test_table')
         self.assertEqual(db_sync.create_query_tag('Loading into {{database}}.{{schema}}.{{table}}',
-                                        database=None,
-                                        schema=None,
-                                        table=None), 'Loading into ..')
+                                                  database=None,
+                                                  schema=None,
+                                                  table=None), 'Loading into ..')
 
         # JSON formatted query tags with variables
         json_query_tag = db_sync.create_query_tag(
@@ -200,7 +201,7 @@ class TestDBSync(unittest.TestCase):
 
     @patch('target_snowflake.db_sync.DbSync.query')
     def test_parallelism(self, query_patch):
-        query_patch.return_value = [{ 'type': 'CSV' }]
+        query_patch.return_value = [{'type': 'CSV'}]
 
         minimal_config = {
             'account': "dummy-value",
@@ -288,7 +289,7 @@ class TestDBSync(unittest.TestCase):
         stream_schema_message = {"stream": "public-table1",
                                  "schema": {
                                      "properties": {
-                                         "id": { "type": ["integer"]},
+                                         "id": {"type": ["integer"]},
                                          "c_str": {"type": ["null", "string"]}}},
                                  "key_properties": ["id"]}
 
@@ -503,7 +504,7 @@ class TestDBSync(unittest.TestCase):
         self.assertEqual('alter table dummy-schema."TABLE1" drop primary key;', calls[2][0][0][0])
 
         self.assertIn(calls[2][0][0][1], {'alter table dummy-schema."TABLE1" add primary key("ID", "NAME");',
-                                       'alter table dummy-schema."TABLE1" add primary key("NAME", "ID");'})
+                                          'alter table dummy-schema."TABLE1" add primary key("NAME", "ID");'})
 
         self.assertListEqual(sorted(calls[2][0][0][2:]),
                              [
@@ -558,5 +559,54 @@ class TestDBSync(unittest.TestCase):
             call('SHOW FILE FORMATS LIKE \'dummy-file-format\''),
             call('show primary keys in table dummy-db.dummy-schema."TABLE1";'),
             call(['alter table dummy-schema."TABLE1" drop primary key;',
+                  'alter table dummy-schema."TABLE1" alter column "ID" drop not null;'])
+        ])
+
+    @patch('target_snowflake.db_sync.DbSync.query')
+    def test_sync_table_with_stream_that_has_no_pk_but_get_a_new_one(self, query_patch):
+        minimal_config = {
+            'account': "dummy-account",
+            'dbname': "dummy-db",
+            'user': "dummy-user",
+            'password': "dummy-passwd",
+            'warehouse': "dummy-wh",
+            'default_target_schema': "dummy-schema",
+            'file_format': "dummy-file-format"
+        }
+
+        stream_schema_message = {"stream": "public-table1",
+                                 "schema": {
+                                     "properties": {
+                                         "id": {"type": ["integer"]},
+                                         "c_str": {"type": ["null", "string"]}}},
+                                 "key_properties": ['id']}
+
+        table_cache = [
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER'
+            },
+            {
+                'SCHEMA_NAME': 'DUMMY-SCHEMA',
+                'TABLE_NAME': 'TABLE1',
+                'COLUMN_NAME': 'C_STR',
+                'DATA_TYPE': 'TEXT'
+            }
+        ]
+        query_patch.side_effect = [
+            [{'type': 'CSV'}],
+            [],
+            None
+        ]
+
+        dbsync = db_sync.DbSync(minimal_config, stream_schema_message, table_cache)
+        dbsync.sync_table()
+
+        query_patch.assert_has_calls([
+            call('SHOW FILE FORMATS LIKE \'dummy-file-format\''),
+            call('show primary keys in table dummy-db.dummy-schema."TABLE1";'),
+            call(['alter table dummy-schema."TABLE1" add primary key("ID");',
                   'alter table dummy-schema."TABLE1" alter column "ID" drop not null;'])
         ])


### PR DESCRIPTION
## Problem

1. target runs `alter table .. drop primary key` even when table has no such constraint
2. target raises `PrimaryKeyNotFoundException` when it encounteres a record where pk value is falsy

## Proposed changes

1. only drop pk constraint if it exists
2.  only raise `PrimaryKeyNotFoundException` if  pk field in record is either non-existent or is explicitly null.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions