### PR TITLE
Adds support for MFA token caching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name="pipelinewise-target-snowflake",
       python_requires='>=3.7',
       install_requires=[
           'pipelinewise-singer-python==1.*',
-          'snowflake-connector-python[pandas]==2.7.*',
+          'snowflake-connector-python[secure-local-storage,pandas]==2.7.*',
           'inflection==0.5.1',
           'joblib==1.1.0',
           'boto3==1.23.10',

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -299,6 +299,9 @@ class DbSync:
             warehouse=self.connection_config['warehouse'],
             role=self.connection_config.get('role', None),
             autocommit=True,
+            authenticator='username_password_mfa',
+            client_store_temporary_credential=True,
+            client_request_mfa_token=True,
             session_parameters={
                 # Quoted identifiers should be case sensitive
                 'QUOTED_IDENTIFIERS_IGNORE_CASE': 'FALSE',


### PR DESCRIPTION
## Problem
Described in #305 - Allows a user who has MFA to only authenticate once per meltano run (instead of once for each snowflake query).

## Proposed changes

Added the secure storage package and set the authenticator to `username_password_mfa` as described in the [Snowflake docs](https://docs.snowflake.com/en/user-guide/security-mfa.html#label-mfa-token-caching).

While the authenticator is set to `username_password_mfa`, it works even if the user doesn't have MFA enabled.  Since username/password is the only supported authentication method, this should have no impact on existing users who don't use MFA.  We'd probably need more complex connection configuration logic if it was decided to use other auth methods (like OAuth or keypair).


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions