### PR TITLE
fix - Add default schema name to S3 archive metadata

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -478,7 +478,7 @@ def flush_records(stream: str,
         if 'schema_name' not in stream_name_parts or 'table_name' not in stream_name_parts:
             raise Exception(f"Failed to extract schema and table names from stream '{stream}'")
 
-        archive_schema = stream_name_parts['schema_name']
+        archive_schema = stream_name_parts['schema_name'] if stream_name_parts['schema_name'] is not None else db_sync.schema_name
         archive_table = stream_name_parts['table_name']
         archive_tap = archive_load_files['tap']
 


### PR DESCRIPTION
## Problem

Closes same issue as [Pipeline fails if archive enabled with s3 and tap table name is not in format <<schema_name>>__<<table>>](https://github.com/transferwise/pipelinewise-target-snowflake/issues/235)

## Proposed changes
Add a default schema_name to the S3 metadata, also happy to just set this to an empty string if you prefer?


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions