### PR TITLE
Fix table_cache when disable_table_cache is set to True

### DIFF
--- a/target_snowflake/__init__.py
+++ b/target_snowflake/__init__.py
@@ -70,11 +70,10 @@ def get_snowflake_statics(config):
     Returns:
         tuple of retrieved items: table_cache, file_format_type
     """
-    table_cache = []
+    table_cache = None    
+    db = DbSync(config)  # pylint: disable=invalid-name
     if not ('disable_table_cache' in config and config['disable_table_cache']):
         LOGGER.info('Getting catalog objects from table cache...')
-
-        db = DbSync(config)  # pylint: disable=invalid-name
         table_cache = db.get_table_columns(
             table_schemas=stream_utils.get_schema_names_from_config(config))
 


### PR DESCRIPTION
## Problem

_Describe the problem your PR is trying to solve_

When setting `disable_table_cache` to True the target throws the following error when trying to retrieve the `file_format_type` from the `db` object.
```
UnboundLocalError: local variable 'db' referenced before assignment
```

## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue._

With this change, we define the db object outside of the if statement to avoid the above record. We also set the default value of `table_cache=None` as defined in `persist_lines` and `DbSync` class.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions