### PR TITLE
forced nullability was switched of for PK's

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -854,10 +854,6 @@ class DbSync:
 
             queries.append(f'alter table {table_name} add primary key({pk_list});')
 
-        # For now, we don't wish to enforce non-nullability on the pk columns
-        for pk in current_pks.union(new_pks):
-            queries.append(f'alter table {table_name} alter column {safe_column_name(pk)} drop not null;')
-
         self.query(queries)
 
     def _get_current_pks(self) -> Set[str]:


### PR DESCRIPTION
## Problem

forced nullability was switched of for PK's

## Proposed changes

For now, we don't wish to enforce non-nullability on the pk columns.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
