### PR TITLE
Use `VARIANT` type for properties without a type

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -103,7 +103,6 @@ def column_trans(schema_property):
     """Generate SQL transformed columns syntax"""
     property_type = schema_property.get('type')
     col_trans = ''
-
     if property_type is None:
         col_trans = 'to_variant'
     elif 'object' in property_type or 'array' in property_type:

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -103,12 +103,13 @@ def column_trans(schema_property):
     """Generate SQL transformed columns syntax"""
     property_type = schema_property.get('type')
     col_trans = ''
-    if 'object' in property_type or 'array' in property_type:
+
+    if property_type is None:
+        col_trans = 'to_variant'
+    elif 'object' in property_type or 'array' in property_type:
         col_trans = 'parse_json'
     elif schema_property.get('format') == 'binary':
         col_trans = 'to_binary'
-    elif property_type is None:
-        col_trans = 'to_variant'
 
     return col_trans
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -72,10 +72,10 @@ def validate_config(config):
 
 def column_type(schema_property):
     """Take a specific schema property and return the snowflake equivalent column type"""
-    property_type = schema_property['type']
-    property_format = schema_property['format'] if 'format' in schema_property else None
+    property_type = schema_property.get('type')
+    property_format = schema_property.get('format')
     col_type = 'text'
-    if 'object' in property_type or 'array' in property_type:
+    if 'object' in property_type or 'array' in property_type or property_type is None:
         col_type = 'variant'
 
     # Every date-time JSON value is currently mapped to TIMESTAMP_NTZ
@@ -101,12 +101,14 @@ def column_type(schema_property):
 
 def column_trans(schema_property):
     """Generate SQL transformed columns syntax"""
-    property_type = schema_property['type']
+    property_type = schema_property.get('type')
     col_trans = ''
     if 'object' in property_type or 'array' in property_type:
         col_trans = 'parse_json'
     elif schema_property.get('format') == 'binary':
         col_trans = 'to_binary'
+    elif property_type is None:
+        col_trans = 'to_variant'
 
     return col_trans
 

--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -75,7 +75,7 @@ def column_type(schema_property):
     property_type = schema_property.get('type')
     property_format = schema_property.get('format')
     col_type = 'text'
-    if 'object' in property_type or 'array' in property_type or property_type is None:
+    if property_type is None or 'object' in property_type or 'array' in property_type:
         col_type = 'variant'
 
     # Every date-time JSON value is currently mapped to TIMESTAMP_NTZ

--- a/target_snowflake/stream_utils.py
+++ b/target_snowflake/stream_utils.py
@@ -66,8 +66,10 @@ def adjust_timestamps_in_record(record: Dict, schema: Dict) -> None:
                         reset_new_value(record, key, type_dict['format'])
                         break
             else:
-                if 'string' in schema['properties'][key]['type'] and \
-                        schema['properties'][key].get('format', None) in {'date-time', 'time', 'date'}:
+                property_type = schema['properties'][key].get('type')
+                property_format = schema['properties'][key].get('format')
+                if property_type is not None and 'string' in property_type and \
+                        property_format in {'date-time', 'time', 'date'}:
                     reset_new_value(record, key, schema['properties'][key]['format'])
 
 


### PR DESCRIPTION
## Problem

As described in this [issue](https://github.com/transferwise/pipelinewise-target-snowflake/issues/88), the current implementation of the target does not handle columns without a type (property definition as `"property_name": {}`) given that:
1. The `target` assumes the existence of a `type` in the property definition (causing expressions like `schema["type"]` to fail)
2. It is unclear on which database Snowflake type should be chosen. 

As also detailed in the issue, this type of "loose schemas" is common in Salesforce `<some_salesforce_entity>History` entities, which essentially can track the history of any field in the main entity (`<some_salesforce_entity>`) and does so via two fields `OldValue` and `NewValue`. Depending on which fields the history is being tracked, the actual values can vary in type.

## Proposed changes

As suggested in this [comment](https://github.com/transferwise/pipelinewise-target-snowflake/issues/88#issuecomment-654142424), I decided to use Snowflake's `VARIANT` field for these cases.

We could go about it in multiple ways. I noticed that Stitch actually creates multiple fields (e.g. `oldvalue_bl` if `boolean` type is detected, `oldvalue_st` if `string` is detected, etc), although not really sure how we could decide on which fields to create without "parsing" the records or receiving a `anyOf` definition in the schema, so I decided to go with more of a pragmatic approach as `VARIANT` should be able to handle pretty much any data type.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions