### PR TITLE
Don't set data retention time when creating a table

### DIFF
--- a/target_snowflake/db_sync.py
+++ b/target_snowflake/db_sync.py
@@ -565,7 +565,7 @@ class DbSync:
         p_temp = 'TEMP ' if is_temporary else ''
         p_table_name = self.table_name(stream_schema_message['stream'], is_temporary)
         p_columns = ', '.join(columns + primary_key)
-        p_extra = 'data_retention_time_in_days = 0 ' if is_temporary else 'data_retention_time_in_days = 1 '
+        p_extra = 'data_retention_time_in_days = 0 ' if is_temporary else ''
         return f'CREATE {p_temp}TABLE IF NOT EXISTS {p_table_name} ({p_columns}) {p_extra}'
 
     def grant_usage_on_schema(self, schema_name, grantee):


### PR DESCRIPTION
Workaround for https://github.com/transferwise/pipelinewise-target-snowflake/issues/331

## Problem

We have the DATA_RETENTION_TIME_IN_DAYS snowflake parameter set to 90 at the account level. However, when this target creates a table [it's hardcoded to 1 day](https://github.com/transferwise/pipelinewise-target-snowflake/blob/1cb4fbc2319957549a63df545f3ba84296029f3d/target_snowflake/db_sync.py#L568). This was discovered when we tried to use time travel to investigate a data issue and found we couldn't look back far enough.

https://github.com/transferwise/pipelinewise-target-snowflake/issues/331

## Proposed changes

Don't modify the data retention time.

This is technically a breaking change since the existing version always sets the retention time to 1 day.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions